### PR TITLE
Add support for flat file hierarchy

### DIFF
--- a/code/+nansen/+config/+dloc/@DataLocationModel/DataLocationModel.m
+++ b/code/+nansen/+config/+dloc/@DataLocationModel/DataLocationModel.m
@@ -73,7 +73,7 @@ classdef DataLocationModel < utility.data.StorableCatalog
                 'VariableName', varNames, ...
                 'SubfolderLevel', {[]}, ...
                 'StringDetectMode', repmat({'ind'}, 1, numVars), ...
-                'StringDetectInput', repmat({''}, 1, numVars), ...
+                'StringDetectInput', repmat({'1:end'}, 1, numVars), ...
                 'StringFormat', repmat({''}, 1, numVars), ...
                 'FunctionName', repmat({''}, 1, numVars) );
         end
@@ -84,7 +84,8 @@ classdef DataLocationModel < utility.data.StorableCatalog
                 'Name', '', ... % FolderName
                 'Type', '', ...
                 'Expression', '', ...
-                'IgnoreList', {{}} );
+                'IgnoreList', {{}}, ...
+                'IsFolder', true);
             % Todo: Add ShortName, i.e sub / ses (ref BIDS)
         end
     end
@@ -167,6 +168,10 @@ classdef DataLocationModel < utility.data.StorableCatalog
                         dirty = true;
                     elseif isstring(obj.Data(i).SubfolderStructure(j).Type)
                         obj.Data(i).SubfolderStructure(j).Type = char(obj.Data(i).SubfolderStructure(j).Type);
+                        dirty = true;
+                    end
+                    if ~isfield(obj.Data(i).SubfolderStructure, 'IsFolder')
+                        [obj.Data(i).SubfolderStructure(:).IsFolder] = deal(true);
                         dirty = true;
                     end
                 end

--- a/code/+nansen/+config/+project/@ProjectManager/ProjectManager.m
+++ b/code/+nansen/+config/+project/@ProjectManager/ProjectManager.m
@@ -938,12 +938,20 @@ classdef ProjectManager < handle
         
         function checkProjectsExist(obj)
         % checkProjectsExist - Check if project folders exists.
+            missingProjectNames = string.empty;
+            missingProjectPaths = string.empty;
+
             for i = 1:numel(obj.Catalog)
                 thisProjectDir = obj.Catalog(i).Path;
                 if ~isfolder(thisProjectDir)
                     thisProjectName = obj.Catalog(i).Name;
-                    showProjectMissingWarning(thisProjectName, thisProjectDir)
+                    missingProjectNames(end+1) = obj.Catalog(i).Name; %#ok<AGROW>
+                    missingProjectPaths(end+1) = obj.Catalog(i).Path; %#ok<AGROW>
+                    %showProjectMissingWarning(thisProjectName, thisProjectDir)
                 end
+            end
+            if ~isempty(missingProjectNames)
+                showProjectMissingWarning2(missingProjectNames, missingProjectPaths)
             end
         end
 
@@ -1015,8 +1023,29 @@ function showProjectMissingWarning(projectName, projectFolder)
     nansen.common.tracelesswarning(...
         'NANSEN:ProjectManager:ProjectMissing', ...
         ['Project "%s" was not found at expected location:\n%s\nRun ', ...
-        'nansen.ProjectManager to remove the project or update it''s location.'], ...
+        'nansen.ProjectManager to remove the project or update it''s location.\n'], ...
         projectName, projectFolder)
+end
+
+function showProjectMissingWarning2(projectNames, projectFolders)
+    
+    projectList = compose("  %s -> %s", projectNames', projectFolders');
+    projectList = strjoin(projectList, newline);
+    
+    if numel(projectNames) == 1
+        warningMessage = sprintf(...
+            ['The following project was not found:\n%s\nRun ', ...
+            'nansen.ProjectManager to remove the project or update it''s ', ...
+            'location.\n'], projectList);
+    else
+        warningMessage = sprintf(...
+            ['The following projects were not found:\n%s\nRun ', ...
+            'nansen.ProjectManager to remove the projects or update their ', ...
+            'locations.\n'], projectList);
+    end
+
+    nansen.common.tracelesswarning(...
+        'NANSEN:ProjectManager:ProjectMissing', warningMessage)
 end
 
 % Change log

--- a/code/+nansen/+config/+varmodel/VariableModel.m
+++ b/code/+nansen/+config/+varmodel/VariableModel.m
@@ -401,7 +401,7 @@ classdef VariableModel < utility.data.StorableCatalog %& utility.data.mixin.Cata
     end
     
     methods % Todo: Move to nansen.dataio.DataVariable
-        function fileName = lookForFile(obj, folderPath, variableInfo)
+        function fileName = lookForFile(obj, folderPath, variableInfo, options)
 
             % Todo: Add FEX:recursiveDir as dependency and ensure the
             % following works:
@@ -412,6 +412,13 @@ classdef VariableModel < utility.data.StorableCatalog %& utility.data.mixin.Cata
             % %
             % % L = recursiveDir(sessionFolder, nvPairs{:});
             
+            arguments
+                obj
+                folderPath (1,1) string
+                variableInfo
+                options.FilterFcn = []
+            end
+
             if isa(variableInfo, 'char')
                 variableInfo = obj.getVariableStructure(variableInfo);
             end
@@ -426,6 +433,10 @@ classdef VariableModel < utility.data.StorableCatalog %& utility.data.mixin.Cata
             
             L = dir(fullfile(folderPath, expression));
             L = L(~strncmp({L.name}, '.', 1));
+
+            if ~isempty(options.FilterFcn)
+                L = L(options.FilterFcn({L.name}));
+            end
             
             if ~isempty(L) && numel(L)==1
                 fileName = L.name;

--- a/code/+nansen/+dataio/+session/listSessionFolders.m
+++ b/code/+nansen/+dataio/+session/listSessionFolders.m
@@ -53,7 +53,17 @@ function sessionFolders = listSessionFolders(dataLocationModel, dataLocationName
         for j = 1:numel(S) % Loop through each subfolder level
             expression = S(j).Expression;
             ignoreList = S(j).IgnoreList;
-            [rootPath, ~] = utility.path.listSubDir(rootPath, expression, ignoreList, 1);
+            if S(j).IsFolder
+                [rootPath, ~] = utility.path.listSubDir(rootPath, expression, ignoreList, 1);
+            else
+                %[rootPath, ~] = utility.path.listFiles(rootPath);
+                rootPath = recursiveDir(rootPath, ...
+                    "Expression", expression, ...
+                    "IgnoreList", ignoreList, ...
+                    "RecursionDepth", 1, ...
+                    "Type", "file", ...
+                    "OutputType", "FilePath");
+            end
         end
                 
         fieldName = dataLocationModel.Data(i).Name;

--- a/code/+nansen/+internal/+user/@NansenUserSession/NansenUserSession.m
+++ b/code/+nansen/+internal/+user/@NansenUserSession/NansenUserSession.m
@@ -272,6 +272,8 @@ classdef NansenUserSession < handle
             if obj.AddonManager.existExternalToolboxInRepository()
                 obj.AddonManager.moveExternalToolboxes() % Todo: Remove
             end
+
+            obj.ProjectManager.checkProjectsExist()
             
             if obj.ProjectManager.hasUnversionedProjects()
                 obj.ProjectManager.upgradeProjects()

--- a/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/DataLocation.m
+++ b/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/DataLocation.m
@@ -66,6 +66,13 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                         rootPath = obj(i).Value.(dataLocationNames{j});
                         subFolder = rootPath;
                     end
+
+                    % Subfolder might be a file, if using "virtual" folder
+                    % mode where a folder level is actually consisting of
+                    % files and not subfolders.
+                    if isfile(fullfile(rootPath, subFolder))
+                        subFolder = fileparts(subFolder);
+                    end
                     
                     if isempty(rootPath)
                         tmpStr = obj.getIconHtmlString('dot_off');


### PR DESCRIPTION
Some datasets have multiple files from different sessions in the same folder. This is a quick fix that allows creating a project for such configurations.

Note:
- All the files must have a "session id" (i.e unique identifier per session/trial/epoch) in the file name for this to work