### PR TITLE
Add auto-expansion of rows to include dynamic table variables when adding entries to MetaTable

### DIFF
--- a/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
+++ b/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
@@ -122,6 +122,7 @@ classdef MetadataEntity < ...
 
             currentProject = nansen.getCurrentProject();
             variableAttributes = currentProject.getTable('TableVariable');
+            disp(variableAttributes)
             
             keep = variableAttributes.TableType == lower(entityType) ...
                 & variableAttributes.IsCustom;

--- a/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
+++ b/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
@@ -122,7 +122,6 @@ classdef MetadataEntity < ...
 
             currentProject = nansen.getCurrentProject();
             variableAttributes = currentProject.getTable('TableVariable');
-            disp(variableAttributes)
             
             keep = variableAttributes.TableType == lower(entityType) ...
                 & variableAttributes.IsCustom;

--- a/code/+nansen/+metadata/@MetaTable/MetaTable.m
+++ b/code/+nansen/+metadata/@MetaTable/MetaTable.m
@@ -1581,8 +1581,8 @@ classdef MetaTable < handle
 
             % Temporarily create a new MetaTable and add missing table
             % variables
-            tempTable = nansen.metadata.MetaTable.newLike(newTableRows, obj);
-            tempTable.addMissingVarsToMetaTable(tmpMetaTable.MetaTableClass, ...
+            tempMetaTable = nansen.metadata.MetaTable.newLike(newTableRows, obj);
+            tempMetaTable.addMissingVarsToMetaTable(tmpMetaTable.MetaTableClass, ...
                 "AutoUpdateValues", options.AutoUpdateValues);
             
             % Todo (alternative to creating a temp table):
@@ -1592,11 +1592,11 @@ classdef MetaTable < handle
             % Concatenate tables
             try
                 % Try direct concatenation
-                obj.entries = [obj.entries; tmpMetaTable.entries];
+                obj.entries = [obj.entries; tempMetaTable.entries];
             catch
                 % Fallback: convert to struct, concatenate, then back to table
                 obj.entries = struct2table([table2struct(obj.entries); ...
-                                            table2struct(tmpMetaTable.entries)]);
+                                            table2struct(tempMetaTable.entries)]);
             end
             
             % Update member list

--- a/code/+nansen/+metadata/@MetaTable/MetaTable.m
+++ b/code/+nansen/+metadata/@MetaTable/MetaTable.m
@@ -1582,7 +1582,7 @@ classdef MetaTable < handle
             % Temporarily create a new MetaTable and add missing table
             % variables
             tempMetaTable = nansen.metadata.MetaTable.newLike(newTableRows, obj);
-            tempMetaTable.addMissingVarsToMetaTable(tmpMetaTable.MetaTableClass, ...
+            tempMetaTable.addMissingVarsToMetaTable(tempMetaTable.MetaTableClass, ...
                 "AutoUpdateValues", options.AutoUpdateValues);
             
             % Todo (alternative to creating a temp table):

--- a/tests/+nansen/+unittest/+metadata/MetaTableAdvancedTest.m
+++ b/tests/+nansen/+unittest/+metadata/MetaTableAdvancedTest.m
@@ -30,6 +30,9 @@ classdef MetaTableAdvancedTest < matlab.unittest.TestCase
                 error('MetaTable class not found on path');
             end
         end
+        function setupProject(testCase)
+            testCase.applyFixture(nansen.fixture.ProjectFixture)
+        end
     end
     
     methods (TestMethodSetup)

--- a/tests/+nansen/+unittest/+metadata/MetaTableTest.m
+++ b/tests/+nansen/+unittest/+metadata/MetaTableTest.m
@@ -35,6 +35,9 @@ classdef MetaTableTest < matlab.unittest.TestCase
                 error('MetaTable class not found on path');
             end
         end
+        function setupProject(testCase)
+            testCase.applyFixture(nansen.fixture.ProjectFixture)
+        end
     end
     
     methods (TestMethodSetup)

--- a/tests/+nansen/+unittest/+metadata/MetadataEntityTest.m
+++ b/tests/+nansen/+unittest/+metadata/MetadataEntityTest.m
@@ -31,7 +31,13 @@ classdef MetadataEntityTest < matlab.unittest.TestCase
 
             sessionObject.addDynamicTableVariables()
 
-            sessionObject.updateDynamicVariable('BrainRegion')
+            try
+                sessionObject.updateDynamicVariable('BrainRegion')
+            catch
+                pause(1)
+                rehash
+                sessionObject.updateDynamicVariable('BrainRegion')
+            end
             %keyboard
         end
         

--- a/tests/+nansen/+unittest/+metadata/MetadataEntityTest.m
+++ b/tests/+nansen/+unittest/+metadata/MetadataEntityTest.m
@@ -31,7 +31,7 @@ classdef MetadataEntityTest < matlab.unittest.TestCase
 
             % Pause for a second to to give some time for internal
             % registration of the new table variable. 
-            % Todo: this shoud be immediatelty updated
+            % Todo: this should be immediately updated
             pause(1)
             sessionObject.addDynamicTableVariables()
 

--- a/tests/+nansen/+unittest/+metadata/MetadataEntityTest.m
+++ b/tests/+nansen/+unittest/+metadata/MetadataEntityTest.m
@@ -29,16 +29,13 @@ classdef MetadataEntityTest < matlab.unittest.TestCase
             sourceFile = fullfile(sourceFile.folder, sourceFile.name);
             copyfile(sourceFile, targetFolder)
 
+            % Pause for a second to to give some time for internal
+            % registration of the new table variable. 
+            % Todo: this shoud be immediatelty updated
+            pause(1)
             sessionObject.addDynamicTableVariables()
 
-            try
-                sessionObject.updateDynamicVariable('BrainRegion')
-            catch
-                pause(1)
-                rehash
-                sessionObject.updateDynamicVariable('BrainRegion')
-            end
-            %keyboard
+            sessionObject.updateDynamicVariable('BrainRegion')
         end
         
         function testAddTableVariable(testCase)


### PR DESCRIPTION
- Added autoexpansion of dynamic table variables when adding rows to table
-  Introduced an AutoUpdateValues option to addMissingVarsToMetaTable, addTable, addEntries, and appendTableRows methods, allowing control over whether update functions are automatically called when adding new variables or rows. 
- Refactored method signatures to use MATLAB's arguments block for improved input validation. 
- Added a newLike static method to create MetaTable instances with properties copied from an existing MetaTable.