### PR TITLE
Modernize NANSEN tables with EntityTable backend

### DIFF
--- a/code/+nansen/+internal/+user/@NansenUserSession/NansenUserSession.m
+++ b/code/+nansen/+internal/+user/@NansenUserSession/NansenUserSession.m
@@ -223,7 +223,11 @@ classdef NansenUserSession < handle
         function onCurrentProjectChangedInPreferences(obj, src, evt)
         % Set new current project in project manager.
             if obj.isPreferenceListenerActive('CurrentProjectName')
-                newProjectName = obj.Preferences.CurrentProjectName;
+                newProjectName = char(string(obj.Preferences.CurrentProjectName));
+                currentProjectName = char(string(obj.ProjectManager.CurrentProject));
+                if strcmp(newProjectName, currentProjectName)
+                    return
+                end
                 obj.ProjectManager.setProject(newProjectName)
             end
         end
@@ -232,8 +236,8 @@ classdef NansenUserSession < handle
         % Update value for current project in preferences. Make sure that
         % this is not triggering an event, to avoid infinite update loop.
             obj.deactivatePreferenceListener('CurrentProjectName')
+            cleanupObj = onCleanup(@() obj.activatePreferenceListener('CurrentProjectName'));
             obj.Preferences.CurrentProjectName = evt.NewProjectName;
-            obj.activatePreferenceListener('CurrentProjectName')
         end
     end
 

--- a/code/+nansen/+metadata/+abstract/TableColumnFormatter.m
+++ b/code/+nansen/+metadata/+abstract/TableColumnFormatter.m
@@ -26,4 +26,10 @@ classdef TableColumnFormatter
         str = getCellTooltipString(obj)
         
     end
+
+    methods
+        function str = getCellDisplayStringForContext(obj, displayContext) %#ok<INUSD>
+            str = obj.getCellDisplayString();
+        end
+    end
 end

--- a/code/+nansen/+metadata/+utility/formatTableForDisplay.m
+++ b/code/+nansen/+metadata/+utility/formatTableForDisplay.m
@@ -1,4 +1,4 @@
-function T = formatTableForDisplay(metaTable, columnIndices, rowIndices)
+function T = formatTableForDisplay(metaTable, columnIndices, rowIndices, displayContext)
 %formatTableForDisplay Format a MetaTable's cells for UI display
 %
 %   T = formatTableForDisplay(metaTable) formats all cells.
@@ -12,11 +12,14 @@ function T = formatTableForDisplay(metaTable, columnIndices, rowIndices)
 
     import nansen.metadata.utility.getColumnFormatter
 
-    if nargin < 2 % Get all columns
+    if nargin < 2 || isempty(columnIndices) % Get all columns
         columnIndices = 1:size(metaTable.entries, 2);
     end
-    if nargin < 3 % Get all rows
+    if nargin < 3 || isempty(rowIndices) % Get all rows
         rowIndices = 1:size(metaTable.entries, 1);
+    end
+    if nargin < 4
+        displayContext = 'legacy';
     end
 
     if isempty(metaTable.entries)
@@ -103,6 +106,8 @@ function T = formatTableForDisplay(metaTable, columnIndices, rowIndices)
                 tmpObj = thisFormatter( jColumnValues );
                 if isa(tmpObj, 'cell')
                     formattedValue = tmpObj;
+                elseif ismethod(tmpObj, 'getCellDisplayStringForContext')
+                    formattedValue = tmpObj.getCellDisplayStringForContext(displayContext);
                 else
                     formattedValue = tmpObj.getCellDisplayString();
                 end

--- a/code/+nansen/+metadata/@MetaTable/MetaTable.m
+++ b/code/+nansen/+metadata/@MetaTable/MetaTable.m
@@ -325,6 +325,16 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
                     'Column with name "%s" does not exist in table', columnName)
             end
         end
+
+        function T = getFormattedTableData(obj, columnIndices, rowIndices, displayContext)
+        %getFormattedTableData Format table cells for UI display.
+            if nargin < 2 || isempty(columnIndices); columnIndices = 1:size(obj.entries, 2); end
+            if nargin < 3 || isempty(rowIndices); rowIndices = 1:size(obj.entries, 1); end
+            if nargin < 4; displayContext = 'legacy'; end
+
+            T = nansen.metadata.utility.formatTableForDisplay(...
+                obj, columnIndices, rowIndices, displayContext);
+        end
         
 % % % % Methods for modifying entries
 

--- a/code/+nansen/+ui/+metatable/EntityTableMetaTableViewer.m
+++ b/code/+nansen/+ui/+metatable/EntityTableMetaTableViewer.m
@@ -1,0 +1,2039 @@
+classdef EntityTableMetaTableViewer < handle
+%EntityTableMetaTableViewer NANSEN adapter for the standalone entity table.
+
+    properties (Constant, Hidden)
+        VALID_TABLE_CLASS = {'nansen.metadata.MetaTable', 'table'};
+    end
+
+    properties
+        ShowIgnoredEntries = true
+        AllowTableEdits = true
+        TableFontSize = 12
+        MetaTableType = 'session'
+
+        SelectedEntries
+        CellEditCallback
+        KeyPressCallback
+        MouseDoubleClickedFcn = []
+
+        DeleteColumnFcn = []
+        UpdateColumnFcn = []
+        ResetColumnFcn = []
+        EditColumnFcn = []
+        GetTableVariableAttributesFcn = []
+    end
+
+    properties (SetAccess = private, SetObservable = true)
+        MetaTable
+        MetaTableCell cell
+        MetaTableVariableNames
+        MetaTableVariableAttributes
+    end
+
+    properties (Dependent)
+        ColumnSettings
+        DisplayedRows
+    end
+
+    properties (SetAccess = private)
+        ColumnModel
+        ColumnFilter
+    end
+
+    properties
+        AppRef
+        Parent
+        HTable
+        JTable = []
+
+        ColumnContextMenu = []
+        TableContextMenu = []
+
+        DataFilterMap = []
+        ExternalFilterMap = []
+        FilterChangedListener event.listener
+    end
+
+    properties (Access = private)
+        ColumnSettings_
+        EntityTableView = []
+        EntityTableListeners = []
+        ColumnWidthChangedListener = []
+        RowKeyVariableName = 'NansenRowIndex__'
+        ColumnFilterActive = []
+        ActiveColumnFilterNames (1,:) string = strings(1, 0)
+        IsConstructed = false
+        RequireReset = false
+        MouseMotionCallback = []
+        AutoFitColumnWidths (1,1) logical = true
+        AutoAppliedColumnWidths (1,:) double = []
+        IsApplyingColumnWidths (1,1) logical = false
+        HtmlStyleConfigurationRows = []
+        UseHtmlTable (1,1) logical = false
+    end
+
+    events
+        TableUpdated
+        SelectionChanged
+    end
+
+    methods
+        function obj = EntityTableMetaTableViewer(varargin)
+            nansen.util.ensureEntityTableOnPath()
+            obj.UseHtmlTable = obj.shouldUseHtmlTable();
+            obj.parseInputs(varargin)
+
+            obj.ColumnModel = nansen.ui.MetaTableColumnLayout(...
+                obj, 'ColumnSettings', obj.ColumnSettings);
+            obj.createEntityTable(table.empty, entitytable.ColumnSpec.empty(1, 0))
+            obj.createColumnContextMenu()
+            obj.ColumnFilter = nansen.ui.metatable.ModernMetaTableColumnFilter(obj, obj.AppRef);
+
+            obj.IsConstructed = true;
+
+            if ~isempty(obj.MetaTableCell)
+                obj.refreshTable()
+                obj.HTable.Visible = 'on';
+                drawnow
+            end
+        end
+
+        function delete(obj)
+            obj.captureColumnWidths()
+            obj.deleteColumnWidthListener()
+            obj.deleteEntityTableListeners()
+
+            if ~isempty(obj.EntityTableView) && isvalid(obj.EntityTableView)
+                delete(obj.EntityTableView)
+            elseif ~isempty(obj.HTable) && isvalid(obj.HTable)
+                delete(obj.HTable)
+            end
+
+            if ~isempty(obj.ColumnModel) && isvalid(obj.ColumnModel)
+                delete(obj.ColumnModel)
+            end
+        end
+    end
+
+    methods
+        function rowIndices = get.DisplayedRows(obj)
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView)
+                rowIndices = [];
+            else
+                rowIndices = obj.EntityTableView.getDisplayRowIndex();
+                rowIndices = rowIndices(:).';
+            end
+        end
+
+        function set.MetaTable(obj, newTable)
+            if isa(newTable, 'nansen.metadata.MetaTable')
+                obj.MetaTable = newTable.entries;
+            elseif isa(newTable, 'table')
+                obj.MetaTable = newTable;
+            else
+                error('New value of MetaTable property must be a MetaTable or a table object')
+            end
+
+            obj.onMetaTableSet(newTable)
+        end
+
+        function set.MetaTableType(obj, newValue)
+            oldType = obj.MetaTableType;
+            obj.MetaTableType = lower(newValue);
+            obj.RequireReset = ~strcmpi(oldType, newValue); %#ok<MCSUP>
+        end
+
+        function set.ColumnSettings(obj, newSettings)
+            if isempty(obj.ColumnModel)
+                obj.ColumnSettings_ = newSettings;
+            else
+                obj.ColumnModel.replaceColumnSettings(newSettings);
+                obj.updateColumnLayout()
+            end
+        end
+
+        function colSettings = get.ColumnSettings(obj)
+            if isempty(obj.ColumnModel)
+                colSettings = obj.ColumnSettings_;
+            else
+                colSettings = obj.ColumnModel.settings;
+            end
+        end
+
+        function set.ColumnFilter(obj, newValue)
+            obj.ColumnFilter = newValue;
+            if ~isempty(newValue)
+                obj.onColumnFilterSet()
+            end
+        end
+
+        function set.ShowIgnoredEntries(obj, newValue)
+            assert(islogical(newValue), 'Value for ShowIgnoredEntries must be a boolean')
+            obj.ShowIgnoredEntries = newValue;
+            obj.applySystemFilters()
+        end
+
+        function set.AllowTableEdits(obj, newValue)
+            assert(islogical(newValue), 'Value for AllowTableEdits must be a boolean')
+            obj.AllowTableEdits = newValue;
+            obj.updateColumnEditable()
+        end
+
+        function set.TableFontSize(obj, newValue)
+            obj.TableFontSize = newValue;
+            obj.onTableFontSizeSet()
+        end
+
+        function set.KeyPressCallback(obj, newValue)
+            obj.KeyPressCallback = newValue;
+            obj.setKeyPressFcn(newValue)
+        end
+
+        function set.GetTableVariableAttributesFcn(obj, newValue)
+            obj.GetTableVariableAttributesFcn = newValue;
+            obj.onTableVariableAttributesFcnSet()
+        end
+
+        function set.TableContextMenu(obj, newValue)
+            obj.TableContextMenu = newValue;
+            obj.syncEntityTableContextMenus()
+        end
+
+        function set.ColumnContextMenu(obj, newValue)
+            obj.ColumnContextMenu = newValue;
+            obj.syncEntityTableContextMenus()
+        end
+    end
+
+    methods
+        function cleanup = suspendRefresh(obj)
+            cleanup = obj.suspendEntityTableRefresh();
+        end
+
+        function setBusy(obj, isBusy, message)
+            arguments
+                obj
+                isBusy (1,1) logical
+                message (1,1) string = "Working..."
+            end
+
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView) || ...
+                    ~ismethod(obj.EntityTableView, 'setBusy')
+                return
+            end
+
+            obj.EntityTableView.setBusy(isBusy, message);
+        end
+
+        function refreshColumnModel(obj, syncTable)
+            if nargin < 2
+                syncTable = true;
+            end
+
+            obj.ColumnModel.updateColumnEditableState()
+            if syncTable
+                obj.syncEntityTableColumnSpecs()
+            end
+        end
+
+        function resetTable(obj, resetView)
+            if nargin < 2
+                resetView = true;
+            end
+
+            obj.MetaTable = table.empty;
+
+            if resetView
+                obj.refreshTable(table.empty, true)
+            end
+        end
+
+        function resetColumnFilters(obj)
+            obj.clearUserColumnFilters()
+        end
+
+        function updateCells(obj, rowIdxData, colIdxData, newData)
+            obj.MetaTableCell(rowIdxData, colIdxData) = newData;
+            obj.updateTableView([], false)
+            drawnow
+        end
+
+        function updateTableRow(obj, rowIdxData, tableRowData)
+            colIdx = 1:size(tableRowData, 2);
+            if isa(tableRowData, 'table')
+                tableRowData = table2cell(tableRowData);
+            end
+            obj.updateCells(rowIdxData, colIdx, tableRowData)
+        end
+
+        function updateFormattedTableColumnData(obj, columnName, columnData)
+            columnIndex = find(strcmp(obj.MetaTable.Properties.VariableNames, columnName));
+            obj.MetaTableCell(:, columnIndex) = table2cell(columnData);
+        end
+
+        function appendTableRow(~, ~)
+        end
+
+        function updateVisibleRows(obj, rowInd)
+            [numRows, ~] = size(obj.MetaTable);
+            obj.ExternalFilterMap = false(numRows, 1);
+            obj.ExternalFilterMap(rowInd) = true;
+            obj.applySystemFilters()
+            obj.notifyTableRowsUpdated()
+        end
+
+        function refreshTable(obj, newTable, flushTable)
+            requireReset = isempty(obj.MetaTable) || obj.RequireReset;
+
+            if nargin >= 2 && ~(isnumeric(newTable) && isempty(newTable))
+                obj.MetaTable = newTable;
+            end
+
+            if nargin < 3 || isempty(flushTable)
+                flushTable = requireReset;
+            end
+
+            if flushTable
+                obj.DataFilterMap = [];
+                obj.ColumnFilterActive = [];
+                obj.ActiveColumnFilterNames = strings(1, 0);
+                if ~isempty(obj.MetaTable) && ~isempty(obj.ColumnFilter)
+                    obj.ColumnFilter.onMetaTableChanged()
+                end
+                obj.RequireReset = false;
+            elseif ~isempty(obj.ColumnFilter)
+                obj.ColumnFilter.onMetaTableUpdated()
+            end
+
+            drawnow
+            if ~isempty(obj.MetaTable)
+                obj.updateMetaTableVariableAttributes()
+                % EntityTable validates column specs against its current
+                % data, so table refreshes must update data and specs in
+                % the same operation.
+                obj.updateTableView()
+            else
+                obj.createEntityTable(table.empty, entitytable.ColumnSpec.empty(1, 0))
+            end
+        end
+
+        function replaceTable(obj, newTable)
+            obj.MetaTable = newTable;
+            if ~isempty(obj.ColumnFilter)
+                obj.ColumnFilter.onMetaTableChanged()
+            end
+            obj.updateTableView()
+        end
+
+        function rowInd = getMetaTableRows(obj, rowIndDisplay)
+            if isempty(rowIndDisplay)
+                rowInd = [];
+                return
+            end
+
+            displayRows = rowIndDisplay(rowIndDisplay > 0);
+            allDisplayRows = obj.EntityTableView.getDisplayRowIndex();
+            displayRows = displayRows(displayRows <= numel(allDisplayRows));
+            rowInd = allDisplayRows(displayRows);
+
+            if iscolumn(rowInd)
+                rowInd = transpose(rowInd);
+            end
+        end
+
+        function IND = getSelectedEntries(obj)
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView)
+                IND = [];
+                return
+            end
+
+            IND = obj.EntityTableView.getSelectedRowKeys();
+            IND = transpose(double(sort(unique(IND(:)))));
+        end
+
+        function setSelectedEntries(obj, IND, ~)
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView)
+                return
+            end
+
+            if isempty(IND)
+                obj.EntityTableView.setSelectedRowKeys([])
+            else
+                obj.EntityTableView.setSelectedRowKeys(IND(:))
+            end
+        end
+
+        function [columnNames, variableNames] = getColumnNames(obj, columnIndices)
+            if nargin < 2
+                columnIndices = [];
+            end
+
+            [columnNames, variableNames] = obj.ColumnModel.getColumnNames();
+            if ~isempty(columnIndices)
+                columnNames = columnNames(columnIndices);
+                variableNames = variableNames(columnIndices);
+            end
+            if isscalar(columnNames) && iscell(columnNames)
+                columnNames = columnNames{1};
+                variableNames = variableNames{1};
+            end
+        end
+
+        function focusTable(obj)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable)
+                try
+                    uifocus(obj.HTable)
+                catch
+                    hFigure = ancestor(obj.HTable, 'figure');
+                    if ~isempty(hFigure) && isvalid(hFigure)
+                        figure(hFigure)
+                    end
+                end
+            end
+        end
+
+        function setTableTooltip(obj, tooltipText)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable) && isprop(obj.HTable, 'Tooltip')
+                obj.HTable.Tooltip = tooltipText;
+            end
+        end
+
+        function setKeyPressFcn(obj, callback)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable) && isprop(obj.HTable, 'KeyPressFcn')
+                obj.HTable.KeyPressFcn = callback;
+            end
+        end
+
+        function listenerHandle = addMouseMotionCallback(obj, callback)
+            obj.MouseMotionCallback = callback;
+            listenerHandle = [];
+        end
+
+        function flushColumnSettings(obj)
+            obj.captureColumnWidths()
+            obj.captureColumnOrder()
+        end
+
+        function n = getDisplayedRowCount(obj)
+            n = numel(obj.DisplayedRows);
+        end
+
+        function n = getSelectedRowCount(obj)
+            n = numel(obj.getSelectedEntries());
+        end
+
+        function updateTableView(obj, ~, requestFocus)
+            if isempty(obj.ColumnModel) || isempty(obj.MetaTableCell)
+                return
+            end
+            if nargin < 3 || isempty(requestFocus)
+                requestFocus = true;
+            end
+
+            dataTable = obj.buildEntityTableData();
+            columnSpecs = obj.buildEntityTableColumnSpecs();
+            refreshCleanup = obj.suspendEntityTableRefresh();
+            obj.createOrUpdateEntityTable(dataTable, columnSpecs)
+            obj.applySystemFilters()
+
+            obj.HTable.Visible = 'on';
+            obj.syncColumnFormatAndEditable()
+            delete(refreshCleanup)
+
+            if requestFocus
+                obj.focusTable()
+            end
+
+            drawnow
+        end
+
+        function updateColumnLayout(obj)
+            if isempty(obj.ColumnModel)
+                return
+            end
+            if isempty(obj.MetaTable)
+                obj.createEntityTable(table.empty, entitytable.ColumnSpec.empty(1, 0))
+                drawnow
+                return
+            end
+
+            obj.syncEntityTableColumnSpecs()
+        end
+
+        function updateColumnLabelFilterIndicator(obj, filterActive)
+            if nargin < 2
+                if isempty(obj.ColumnFilter)
+                    filterActive = [];
+                else
+                    filterActive = obj.ColumnFilter.isColumnFilterActive;
+                end
+            end
+
+            obj.ColumnFilterActive = filterActive;
+            obj.syncEntityTableColumnSpecs()
+        end
+
+        function popup = openFilterControl(obj, dataColumnIndex)
+            popup = obj.openFilterPopupForDataColumn(dataColumnIndex);
+        end
+
+        function popup = openFilterPopupForDataColumn(obj, dataColumnIndex)
+            popup = [];
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView) || isempty(obj.MetaTable)
+                return
+            end
+            if dataColumnIndex < 1 || dataColumnIndex > numel(obj.MetaTableVariableNames)
+                return
+            end
+
+            variableName = string(obj.MetaTableVariableNames{dataColumnIndex});
+            popup = obj.EntityTableView.showFilterPopup(variableName);
+        end
+
+        function clearUserColumnFilters(obj)
+            obj.ActiveColumnFilterNames = strings(1, 0);
+            obj.updateColumnFilterState()
+
+            if ~isempty(obj.EntityTableView) && isvalid(obj.EntityTableView)
+                obj.EntityTableView.resetFilters()
+                obj.applySystemFilters()
+            else
+                obj.notifyTableRowsUpdated()
+            end
+        end
+
+        function updateColumnEditable(obj)
+            obj.syncEntityTableColumnSpecs()
+            obj.syncColumnFormatAndEditable()
+        end
+
+        function C = getDisplayTableData(obj, rowIndices, columnIndices)
+            C = obj.MetaTableCell(rowIndices, columnIndices);
+            C = cellfun(@obj.normalizeDisplayValue, C, 'UniformOutput', false);
+        end
+
+        function changeColumnNames(obj, newNames)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable) && ...
+                    isprop(obj.HTable, 'ColumnName')
+                obj.HTable.ColumnName = newNames;
+            end
+        end
+
+        function changeColumnWidths(obj, newWidths)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable)
+                obj.setTableColumnWidths(num2cell(newWidths));
+                obj.fitColumnsToTableWidth()
+            end
+        end
+
+        function fitColumnsToTableWidth(obj)
+            if ~obj.AutoFitColumnWidths || isempty(obj.HTable) || ~isvalid(obj.HTable)
+                return
+            end
+
+            columnWidths = obj.getBaseVisibleColumnWidths();
+            if isempty(columnWidths)
+                return
+            end
+
+            tablePosition = obj.getTablePixelPosition();
+            availableWidth = floor(tablePosition(3) - obj.getRowHeaderWidth() - 2);
+            if availableWidth <= 0
+                return
+            end
+
+            currentWidth = sum(columnWidths);
+            if currentWidth <= 0
+                return
+            end
+            if currentWidth >= availableWidth
+                obj.AutoAppliedColumnWidths = [];
+                obj.setTableColumnWidths(num2cell(columnWidths));
+                return
+            end
+
+            fittedWidths = floor(columnWidths .* availableWidth ./ currentWidth);
+            fittedWidths(end) = fittedWidths(end) + availableWidth - sum(fittedWidths);
+            obj.AutoAppliedColumnWidths = fittedWidths;
+            obj.setTableColumnWidths(num2cell(fittedWidths));
+        end
+    end
+
+    methods (Access = private)
+        function tf = shouldUseHtmlTable(~)
+            tf = false;
+            try
+                tf = logical(getpref('nansen', 'useHtmlTable', false));
+            catch
+            end
+            tf = tf && exist('entitytable.backend.HtmlBackend', 'class') == 8;
+        end
+
+        function tableView = createTableView(obj, parent, dataTable, options)
+            arguments
+                obj
+                parent
+                dataTable table
+                options.RowKey = []
+                options.ColumnSpecs = []
+                options.SelectionMode (1,1) string = "multiple"
+            end
+
+            backend = "uitable";
+            if obj.UseHtmlTable
+                backend = "html";
+            end
+
+            tableView = entitytable.EntityTableView(parent, dataTable, ...
+                RowKey=options.RowKey, ...
+                ColumnSpecs=options.ColumnSpecs, ...
+                SelectionMode=options.SelectionMode, ...
+                Backend=backend);
+        end
+
+        function cleanup = suspendEntityTableRefresh(obj)
+            cleanup = onCleanup(@() []);
+            if isempty(obj.EntityTableView) || ...
+                    ~isvalid(obj.EntityTableView) || ...
+                    ~ismethod(obj.EntityTableView, 'suspendRefresh')
+                return
+            end
+
+            cleanup = obj.EntityTableView.suspendRefresh();
+        end
+
+        function parseInputs(obj, listOfArgs)
+            [nvPairs, remainingArgs] = utility.getnvpairs(listOfArgs);
+
+            for i = 1:2:numel(nvPairs)
+                if isprop(obj, nvPairs{i})
+                    obj.(nvPairs{i}) = nvPairs{i+1};
+                end
+            end
+
+            if isempty(remainingArgs)
+                return
+            end
+
+            if isgraphics(remainingArgs{1})
+                obj.Parent = remainingArgs{1};
+                remainingArgs = remainingArgs(2:end);
+            end
+
+            if isempty(remainingArgs)
+                return
+            end
+
+            if obj.isValidTableClass(remainingArgs{1})
+                obj.MetaTable = remainingArgs{1};
+            end
+        end
+
+        function createEntityTable(obj, dataTable, columnSpecs)
+            if isempty(obj.Parent)
+                obj.Parent = uifigure(...
+                    'Name', 'NANSEN Metadata Table', ...
+                    'Visible', 'on');
+            end
+
+            tableLayout = obj.captureTableLayout();
+            obj.deleteEntityTableListeners()
+            if ~isempty(obj.EntityTableView) && isvalid(obj.EntityTableView)
+                delete(obj.EntityTableView)
+            end
+
+            if isempty(dataTable)
+                placeholderTable = table(strings(0, 1), 'VariableNames', {'Empty'});
+                placeholderSpec = entitytable.ColumnSpec("Empty", ...
+                    DisplayName="", Visible=true, Width=100, Order=1);
+                obj.EntityTableView = obj.createTableView(obj.Parent, ...
+                    placeholderTable, ColumnSpecs=placeholderSpec, ...
+                    SelectionMode="multiple");
+            else
+                obj.EntityTableView = obj.createTableView(obj.Parent, ...
+                    dataTable, RowKey=obj.RowKeyVariableName, ...
+                    ColumnSpecs=columnSpecs, SelectionMode="multiple");
+            end
+
+            obj.HTable = obj.EntityTableView.getComponent();
+            obj.applyTableProperties()
+            obj.restoreTableLayout(tableLayout)
+            obj.attachEntityTableListeners()
+            obj.syncEntityTableContextMenus()
+        end
+
+        function createOrUpdateEntityTable(obj, dataTable, columnSpecs)
+            needsCreate = isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView);
+            schemaChanged = false;
+            if ~needsCreate
+                oldNames = string(obj.EntityTableView.Data.Properties.VariableNames);
+                newNames = string(dataTable.Properties.VariableNames);
+                schemaChanged = ~isequal(oldNames, newNames);
+                needsCreate = schemaChanged && ...
+                    ~(obj.UseHtmlTable && ...
+                    ismethod(obj.EntityTableView, 'setDataAndColumnSpecs'));
+            end
+
+            selectedEntries = obj.getSelectedEntries();
+            if needsCreate
+                obj.createEntityTable(dataTable, columnSpecs)
+            elseif obj.UseHtmlTable && ...
+                    ismethod(obj.EntityTableView, 'setDataAndColumnSpecs')
+                tableLayout = obj.captureTableLayout();
+                obj.EntityTableView.setDataAndColumnSpecs(dataTable, ...
+                    obj.RowKeyVariableName, columnSpecs, ...
+                    ResetInteractionState=schemaChanged);
+                obj.HTable = obj.EntityTableView.getComponent();
+                obj.applyTableProperties()
+                obj.restoreTableLayout(tableLayout)
+                obj.syncEntityTableContextMenus()
+            else
+                tableLayout = obj.captureTableLayout();
+                obj.EntityTableView.ColumnSpecs = columnSpecs;
+                obj.EntityTableView.setData(dataTable, obj.RowKeyVariableName);
+                obj.HTable = obj.EntityTableView.getComponent();
+                obj.applyTableProperties()
+                obj.restoreTableLayout(tableLayout)
+                obj.syncEntityTableContextMenus()
+            end
+
+            if ~isempty(selectedEntries)
+                obj.setSelectedEntries(selectedEntries)
+            end
+        end
+
+        function applyTableProperties(obj)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable)
+                return
+            end
+
+            obj.HTable.Tag = 'MetaTable';
+            if isprop(obj.HTable, 'FontSize')
+                obj.HTable.FontSize = obj.TableFontSize;
+            end
+            if isprop(obj.HTable, 'FontName')
+                obj.HTable.FontName = 'avenir next';
+            end
+            if isprop(obj.HTable, 'Units')
+                obj.HTable.Units = 'normalized';
+            end
+            if isprop(obj.HTable, 'Position')
+                obj.HTable.Position = obj.getInitialTablePosition();
+            end
+            if isprop(obj.HTable, 'Visible')
+                obj.HTable.Visible = 'off';
+            end
+            if isprop(obj.HTable, 'SizeChangedFcn')
+                obj.HTable.SizeChangedFcn = @(~, ~) obj.fitColumnsToTableWidth();
+            end
+            obj.configureColumnRearranging()
+            obj.attachColumnWidthListener()
+            obj.setKeyPressFcn(obj.KeyPressCallback)
+        end
+
+        function tableLayout = captureTableLayout(obj)
+            tableLayout = struct('Units', [], 'Position', []);
+            if isempty(obj.HTable) || ~isvalid(obj.HTable)
+                return
+            end
+
+            if isprop(obj.HTable, 'Units')
+                tableLayout.Units = obj.HTable.Units;
+            end
+            if isprop(obj.HTable, 'Position')
+                tableLayout.Position = obj.HTable.Position;
+            end
+        end
+
+        function restoreTableLayout(obj, tableLayout)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable)
+                return
+            end
+
+            if ~isempty(tableLayout.Units) && isprop(obj.HTable, 'Units')
+                obj.HTable.Units = tableLayout.Units;
+            end
+            if ~isempty(tableLayout.Position) && isprop(obj.HTable, 'Position')
+                obj.HTable.Position = tableLayout.Position;
+            end
+        end
+
+        function width = getRowHeaderWidth(obj)
+            width = 0;
+            try
+                if isprop(obj.HTable, 'RowName') && ~isempty(obj.HTable.RowName)
+                    width = 48;
+                end
+            catch
+            end
+        end
+
+        function tablePosition = getTablePixelPosition(obj)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable)
+                tablePosition = [0 0 0 0];
+            elseif isprop(obj.HTable, 'Units')
+                tablePosition = getpixelposition(obj.HTable, true);
+            elseif isprop(obj.HTable, 'Position')
+                tablePosition = obj.HTable.Position;
+            else
+                tablePosition = [0 0 0 0];
+            end
+        end
+
+        function tablePosition = getInitialTablePosition(obj)
+            if isprop(obj.HTable, 'Units')
+                tablePosition = [0 0 1 1];
+                return
+            end
+
+            tablePosition = [0 0 1 1];
+            try
+                tablePosition = obj.getParentContentPixelPosition();
+            catch
+            end
+        end
+
+        function position = getParentContentPixelPosition(obj)
+            parent = obj.HTable.Parent;
+            if isa(parent, 'matlab.ui.container.Tab') ...
+                    && exist('uim.utility.getContentPixelPosition', 'file') == 2
+                position = uim.utility.getContentPixelPosition(parent);
+            elseif isprop(parent, 'Position')
+                position = [0, 0, parent.Position(3:4)];
+            else
+                position = getpixelposition(parent);
+                position(1:2) = [0, 0];
+            end
+
+            position(3:4) = max(1, position(3:4));
+        end
+
+        function columnWidths = getBaseVisibleColumnWidths(obj)
+            columnWidths = [];
+            if ~isempty(obj.ColumnModel) && isvalid(obj.ColumnModel)
+                columnWidths = obj.ColumnModel.getColumnWidths();
+                columnWidths = obj.normalizeColumnWidths(columnWidths);
+            end
+
+            if isempty(columnWidths)
+                if ismethod(obj.EntityTableView, 'getColumnWidths')
+                    columnWidths = obj.EntityTableView.getColumnWidths();
+                elseif isprop(obj.HTable, 'ColumnWidth')
+                    columnWidths = obj.normalizeColumnWidths(obj.HTable.ColumnWidth);
+                end
+                columnWidths = obj.normalizeColumnWidths(columnWidths);
+            end
+        end
+
+        function configureColumnRearranging(obj)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable)
+                return
+            end
+
+            if isprop(obj.HTable, 'ColumnRearrangeable')
+                obj.HTable.ColumnRearrangeable = true;
+            end
+            if isprop(obj.HTable, 'DisplayDataChangedFcn')
+                obj.HTable.DisplayDataChangedFcn = ...
+                    @(src, evt) obj.onModernDisplayDataChanged(src, evt);
+            end
+        end
+
+        function attachColumnWidthListener(obj)
+            obj.deleteColumnWidthListener()
+            if isempty(obj.HTable) || ~isvalid(obj.HTable)
+                return
+            end
+            if ~isprop(obj.HTable, 'ColumnWidth')
+                return
+            end
+
+            obj.ColumnWidthChangedListener = addlistener(obj.HTable, ...
+                'ColumnWidth', 'PostSet', @(~, ~) obj.onTableColumnWidthChanged());
+        end
+
+        function deleteColumnWidthListener(obj)
+            if ~isempty(obj.ColumnWidthChangedListener)
+                delete(obj.ColumnWidthChangedListener)
+                obj.ColumnWidthChangedListener = [];
+            end
+        end
+
+        function setTableColumnWidths(obj, columnWidths)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable)
+                return
+            end
+
+            obj.IsApplyingColumnWidths = true;
+            cleanup = onCleanup(@() obj.finishApplyingColumnWidths());
+            if ismethod(obj.EntityTableView, 'setColumnWidths')
+                obj.EntityTableView.setColumnWidths(columnWidths);
+            elseif isprop(obj.HTable, 'ColumnWidth')
+                obj.HTable.ColumnWidth = columnWidths;
+            end
+        end
+
+        function finishApplyingColumnWidths(obj)
+            obj.IsApplyingColumnWidths = false;
+        end
+
+        function applyHtmlInterpreterStyles(obj)
+            obj.removeHtmlInterpreterStyles()
+
+            if isempty(obj.HTable) || ~isvalid(obj.HTable) || ...
+                    isempty(obj.ColumnModel) || isempty(obj.MetaTableCell)
+                return
+            end
+            if ~isprop(obj.HTable, 'StyleConfigurations')
+                return
+            end
+
+            visibleColumns = obj.ColumnModel.getColumnIndices();
+            htmlColumns = false(1, numel(visibleColumns));
+            for i = 1:numel(visibleColumns)
+                htmlColumns(i) = obj.isHtmlFormattedColumn(visibleColumns(i));
+            end
+
+            if ~any(htmlColumns)
+                return
+            end
+
+            htmlStyle = uistyle('Interpreter', 'html');
+            addStyle(obj.HTable, htmlStyle, 'column', find(htmlColumns))
+            obj.HtmlStyleConfigurationRows = height(obj.HTable.StyleConfigurations);
+        end
+
+        function removeHtmlInterpreterStyles(obj)
+            if isempty(obj.HtmlStyleConfigurationRows) || ...
+                    isempty(obj.HTable) || ~isvalid(obj.HTable) || ...
+                    ~isprop(obj.HTable, 'StyleConfigurations')
+                obj.HtmlStyleConfigurationRows = [];
+                return
+            end
+
+            try
+                styleRows = obj.HtmlStyleConfigurationRows;
+                styleRows = styleRows(styleRows <= height(obj.HTable.StyleConfigurations));
+                if ~isempty(styleRows)
+                    removeStyle(obj.HTable, styleRows)
+                end
+            catch
+            end
+
+            obj.HtmlStyleConfigurationRows = [];
+        end
+
+        function tf = isHtmlFormattedColumn(obj, columnIndex)
+            columnValues = obj.MetaTableCell(:, columnIndex);
+            tf = any(cellfun(@obj.isHtmlFormattedValue, columnValues));
+        end
+
+        function tf = isHtmlFormattedValue(~, value)
+            if isstring(value) && isscalar(value)
+                value = char(value);
+            end
+
+            tf = ischar(value) && startsWith(strtrim(value), '<html', ...
+                'IgnoreCase', true);
+        end
+
+        function attachEntityTableListeners(obj)
+            obj.deleteEntityTableListeners()
+            obj.EntityTableListeners = [ ...
+                addlistener(obj.EntityTableView, 'SelectionChanged', @obj.onEntitySelectionChanged), ...
+                addlistener(obj.EntityTableView, 'CellEdited', @obj.onEntityCellEdited), ...
+                addlistener(obj.EntityTableView, 'CellActivated', @obj.onEntityCellActivated), ...
+                addlistener(obj.EntityTableView, 'FilterChanged', @obj.onEntityFilterChanged), ...
+                addlistener(obj.EntityTableView, 'ColumnLayoutChanged', @obj.onEntityColumnLayoutChanged), ...
+                addlistener(obj.EntityTableView, 'ContextMenuOpening', @obj.onEntityContextMenuOpening) ...
+                ];
+        end
+
+        function deleteEntityTableListeners(obj)
+            if isempty(obj.EntityTableListeners)
+                return
+            end
+
+            for i = 1:numel(obj.EntityTableListeners)
+                if isvalid(obj.EntityTableListeners(i))
+                    delete(obj.EntityTableListeners(i))
+                end
+            end
+            obj.EntityTableListeners = [];
+        end
+
+        function syncEntityTableContextMenus(obj)
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView)
+                return
+            end
+
+            obj.EntityTableView.TableContextMenu = obj.TableContextMenu;
+            obj.EntityTableView.ColumnHeaderContextMenu = obj.ColumnContextMenu;
+        end
+
+        function createColumnContextMenu(obj)
+        %createColumnContextMenu Create the NANSEN column header menu.
+
+            if ~isempty(obj.ColumnContextMenu) && isvalid(obj.ColumnContextMenu)
+                return
+            end
+
+            hFigure = ancestor(obj.Parent, 'figure');
+            if isempty(hFigure) && ~isempty(obj.HTable) && isvalid(obj.HTable)
+                hFigure = ancestor(obj.HTable, 'figure');
+            end
+            if isempty(hFigure)
+                return
+            end
+
+            obj.ColumnContextMenu = uicontextmenu(hFigure);
+
+            obj.createMenuItem(obj.ColumnContextMenu, 'Sort A-Z', 'Sort Ascend');
+            obj.createMenuItem(obj.ColumnContextMenu, 'Sort Z-A', 'Sort Descend');
+            obj.createMenuItem(obj.ColumnContextMenu, 'Reset Filters', 'Reset Filters', true);
+            obj.createMenuItem(obj.ColumnContextMenu, 'Hide this column', 'Hide Column', true);
+            obj.createMenuItem(obj.ColumnContextMenu, ...
+                'Set column width...', 'Set Column Width');
+
+            hTmp = obj.createMenuItem(obj.ColumnContextMenu, ...
+                'Column settings...', 'ColumnSettings', true);
+            obj.setMenuCallback(hTmp, @(~, ~) obj.ColumnModel.editSettings);
+
+            hTmp = obj.createMenuItem(obj.ColumnContextMenu, ...
+                'Update column data', 'Update Column', true);
+            obj.createMenuItem(hTmp, 'Update selected rows', 'Update selected rows');
+            obj.createMenuItem(hTmp, 'Update all rows', 'Update all rows');
+            obj.createMenuItem(hTmp, 'Reset selected rows', 'Reset selected rows', true);
+            obj.createMenuItem(hTmp, 'Reset all rows', 'Reset all rows');
+            obj.createMenuItem(hTmp, 'Edit tablevar function', ...
+                'Edit tablevar function', true);
+
+            obj.createMenuItem(obj.ColumnContextMenu, ...
+                'Delete this column', 'Delete Column');
+
+            obj.syncEntityTableContextMenus()
+        end
+
+        function hMenu = createMenuItem(obj, parent, text, tag, separator)
+            if nargin < 5
+                separator = false;
+            end
+
+            hMenu = uimenu(parent);
+            obj.setMenuText(hMenu, text);
+            hMenu.Tag = tag;
+            if separator && isprop(hMenu, 'Separator')
+                hMenu.Separator = 'on';
+            end
+        end
+
+        function onEntityContextMenuOpening(obj, ~, evt)
+            if ~isfield(evt.Context, 'Region') || string(evt.Context.Region) ~= "header"
+                return
+            end
+
+            obj.configureColumnContextMenu(evt.DisplayColumn, evt.VariableName)
+        end
+
+        function configureColumnContextMenu(obj, displayColumn, variableName)
+            if isempty(obj.ColumnModel) || isempty(obj.MetaTableVariableAttributes)
+                return
+            end
+            if isempty(displayColumn) || displayColumn < 1
+                return
+            end
+
+            [~, visibleVariableNames] = obj.ColumnModel.getColumnNames();
+            visibleVariableNames = string(visibleVariableNames);
+            if displayColumn > numel(visibleVariableNames)
+                return
+            end
+
+            if isempty(variableName)
+                currentColumnName = visibleVariableNames(displayColumn);
+            else
+                currentColumnName = string(variableName);
+            end
+
+            columnNumber = find(visibleVariableNames == currentColumnName, 1, 'first');
+            if isempty(columnNumber)
+                columnNumber = displayColumn;
+            end
+
+            visibleColumns = obj.ColumnModel.getColumnIndices();
+            columnFormat = obj.getColumnFormatForVisibleColumn(visibleColumns, columnNumber);
+            varAttr = obj.getVariableAttribute(currentColumnName);
+
+            hMenu = obj.EntityTableView.getUnifiedContextMenu();
+            obj.configureColumnContextMenuItems(hMenu, columnNumber, ...
+                currentColumnName, columnFormat, varAttr);
+        end
+
+        function columnFormat = getColumnFormatForVisibleColumn(obj, visibleColumns, columnNumber)
+            columnFormat = 'char';
+            if isempty(visibleColumns) || columnNumber > numel(visibleColumns)
+                return
+            end
+
+            columnFormats = obj.getVisibleColumnFormat(visibleColumns);
+            if columnNumber <= numel(columnFormats)
+                columnFormat = columnFormats{columnNumber};
+            end
+        end
+
+        function varAttr = getVariableAttribute(obj, variableName)
+            attributeNames = string({obj.MetaTableVariableAttributes.Name});
+            tableTypes = string({obj.MetaTableVariableAttributes.TableType});
+            isMatch = attributeNames == string(variableName) & ...
+                strcmpi(tableTypes, obj.MetaTableType);
+
+            if any(isMatch)
+                varAttr = obj.MetaTableVariableAttributes(find(isMatch, 1, 'first'));
+            else
+                error('Variable attributes does not exist. This is unexpected.')
+            end
+        end
+
+        function configureColumnContextMenuItems(obj, hMenu, columnNumber, ...
+                currentColumnName, columnFormat, varAttr)
+            if isempty(hMenu) || ~isvalid(hMenu)
+                return
+            end
+
+            obj.configureSortMenuItem(hMenu, 'Sort Ascend', columnFormat, ...
+                columnNumber, 'ascend');
+            obj.configureSortMenuItem(hMenu, 'Sort Descend', columnFormat, ...
+                columnNumber, 'descend');
+            obj.setTaggedMenuCallback(hMenu, 'Reset Filters', ...
+                @(~, ~) obj.resetColumnFilters());
+            obj.setTaggedMenuCallback(hMenu, 'Hide Column', ...
+                @(~, ~) obj.hideColumn(columnNumber));
+            obj.setTaggedMenuCallback(hMenu, 'Set Column Width', ...
+                @(~, ~) obj.promptColumnWidth(columnNumber));
+            obj.configureUpdateColumnMenu(hMenu, currentColumnName, varAttr);
+            obj.configureDeleteColumnMenu(hMenu, currentColumnName, varAttr);
+        end
+
+        function configureSortMenuItem(obj, hMenu, tag, columnFormat, ...
+                columnNumber, sortDirection)
+            hItem = obj.findTaggedMenuItem(hMenu, tag);
+            if isempty(hItem)
+                return
+            end
+
+            if strcmp(sortDirection, 'ascend')
+                obj.setMenuText(hItem, 'Sort A-Z');
+            else
+                obj.setMenuText(hItem, 'Sort Z-A');
+            end
+
+            if ischar(columnFormat) || (isstring(columnFormat) && isscalar(columnFormat))
+                columnFormat = char(columnFormat);
+                switch columnFormat
+                    case 'numeric'
+                        if strcmp(sortDirection, 'ascend')
+                            obj.setMenuText(hItem, 'Sort low-high');
+                        else
+                            obj.setMenuText(hItem, 'Sort high-low');
+                        end
+                    case 'logical'
+                        if strcmp(sortDirection, 'ascend')
+                            obj.setMenuText(hItem, 'Sort false-true');
+                        else
+                            obj.setMenuText(hItem, 'Sort true-false');
+                        end
+                end
+            end
+
+            obj.setMenuCallback(hItem, ...
+                @(~, ~) obj.sortColumn(columnNumber, sortDirection));
+        end
+
+        function configureUpdateColumnMenu(obj, hMenu, currentColumnName, varAttr)
+            hItem = obj.findTaggedMenuItem(hMenu, 'Update Column');
+            if isempty(hItem)
+                return
+            end
+
+            hasUpdateFunction = isfield(varAttr, 'HasUpdateFunction') && ...
+                varAttr.HasUpdateFunction;
+            if hasUpdateFunction
+                hItem.Enable = 'on';
+                if ~isempty(obj.UpdateColumnFcn)
+                    obj.setTaggedMenuCallback(hItem, 'Update selected rows', ...
+                        @(~, ~) obj.UpdateColumnFcn(currentColumnName, 'SelectedRows'));
+                    obj.setTaggedMenuCallback(hItem, 'Update all rows', ...
+                        @(~, ~) obj.UpdateColumnFcn(currentColumnName, 'AllRows'));
+                    obj.setTaggedMenuCallback(hItem, 'Reset selected rows', ...
+                        @(~, ~) obj.ResetColumnFcn(currentColumnName, 'SelectedRows'));
+                    obj.setTaggedMenuCallback(hItem, 'Reset all rows', ...
+                        @(~, ~) obj.ResetColumnFcn(currentColumnName, 'AllRows'));
+                    obj.setTaggedMenuCallback(hItem, 'Edit tablevar function', ...
+                        @(~, ~) obj.EditColumnFcn(currentColumnName));
+                end
+            else
+                hItem.Enable = 'off';
+            end
+        end
+
+        function configureDeleteColumnMenu(obj, hMenu, currentColumnName, varAttr)
+            hItem = obj.findTaggedMenuItem(hMenu, 'Delete Column');
+            if isempty(hItem)
+                return
+            end
+
+            isCustom = isfield(varAttr, 'IsCustom') && varAttr.IsCustom;
+            if isCustom
+                hItem.Enable = 'on';
+                if ~isempty(obj.DeleteColumnFcn)
+                    obj.setMenuCallback(hItem, ...
+                        @(~, ~) obj.DeleteColumnFcn(currentColumnName));
+                end
+            else
+                hItem.Enable = 'off';
+            end
+        end
+
+        function setTaggedMenuCallback(obj, parent, tag, callbackFcn)
+            hItem = obj.findTaggedMenuItem(parent, tag);
+            if isempty(hItem)
+                return
+            end
+            obj.setMenuCallback(hItem, callbackFcn);
+        end
+
+        function hItem = findTaggedMenuItem(~, parent, tag)
+            hItem = findobj(parent, 'Tag', tag);
+            if isempty(hItem)
+                return
+            end
+            hItem = hItem(1);
+        end
+
+        function setMenuText(~, hItem, text)
+            if isprop(hItem, 'Text')
+                hItem.Text = text;
+            elseif isprop(hItem, 'Label')
+                hItem.Label = text;
+            end
+        end
+
+        function setMenuCallback(~, hItem, callbackFcn)
+            if isprop(hItem, 'Callback')
+                hItem.Callback = callbackFcn;
+            end
+            if isprop(hItem, 'MenuSelectedFcn')
+                hItem.MenuSelectedFcn = callbackFcn;
+            end
+        end
+
+        function sortColumn(obj, columnNumber, sortDirection)
+        %sortColumn Sort column in specified direction.
+
+            visibleColumns = obj.ColumnModel.getColumnIndices();
+            if columnNumber < 1 || columnNumber > numel(visibleColumns)
+                return
+            end
+
+            dataColumnIndex = visibleColumns(columnNumber);
+            variableName = string(obj.MetaTableVariableNames{dataColumnIndex});
+            obj.EntityTableView.sortByColumn(variableName, string(sortDirection))
+            obj.notifyTableRowsUpdated()
+        end
+
+        function hideColumn(obj, columnNumber)
+            obj.ColumnModel.hideColumn(columnNumber);
+        end
+
+        function promptColumnWidth(obj, columnNumber)
+            columnWidths = obj.getCurrentVisibleColumnWidths();
+            if isempty(columnWidths) || columnNumber > numel(columnWidths)
+                return
+            end
+
+            currentWidth = round(columnWidths(columnNumber));
+            answer = inputdlg( ...
+                {'Column width (pixels):'}, ...
+                'Set Column Width', [1 35], {num2str(currentWidth)});
+            if isempty(answer)
+                return
+            end
+
+            newWidth = str2double(answer{1});
+            if isnan(newWidth) || ~isfinite(newWidth) || newWidth <= 0
+                return
+            end
+
+            columnWidths(columnNumber) = max(20, round(newWidth));
+            obj.AutoAppliedColumnWidths = [];
+            obj.ColumnModel.setColumnWidths(columnWidths);
+            obj.setTableColumnWidths(num2cell(columnWidths));
+        end
+
+        function syncEntityTableColumnSpecs(obj)
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView) || isempty(obj.MetaTable)
+                return
+            end
+
+            obj.EntityTableView.ColumnSpecs = obj.buildEntityTableColumnSpecs();
+            obj.syncColumnFormatAndEditable()
+        end
+
+        function syncColumnFormatAndEditable(obj)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable) || isempty(obj.MetaTable)
+                return
+            end
+
+            visibleColumns = obj.ColumnModel.getColumnIndices();
+            if isempty(visibleColumns)
+                return
+            end
+
+            columnEditable = obj.getVisibleColumnEditable();
+            columnFormat = obj.getVisibleColumnFormat(visibleColumns);
+            if ismethod(obj.EntityTableView, 'setColumnFormatAndEditable')
+                obj.EntityTableView.setColumnFormatAndEditable(columnFormat, columnEditable)
+            else
+                if isprop(obj.HTable, 'ColumnEditable')
+                    obj.HTable.ColumnEditable = columnEditable;
+                end
+                if isprop(obj.HTable, 'ColumnFormat')
+                    obj.HTable.ColumnFormat = columnFormat;
+                end
+            end
+            obj.applyHtmlInterpreterStyles()
+            obj.configureColumnRearranging()
+            obj.fitColumnsToTableWidth()
+        end
+
+        function dataTable = buildEntityTableData(obj)
+            if isempty(obj.MetaTable)
+                dataTable = table.empty;
+                return
+            end
+
+            dataTable = cell2table(obj.MetaTableCell, ...
+                'VariableNames', obj.MetaTableVariableNames);
+            dataTable.(obj.RowKeyVariableName) = (1:height(dataTable)).';
+        end
+
+        function columnSpecs = buildEntityTableColumnSpecs(obj)
+            if isempty(obj.MetaTable)
+                columnSpecs = entitytable.ColumnSpec.empty(1, 0);
+                return
+            end
+
+            variableNames = string(obj.MetaTableVariableNames);
+            visibleColumns = obj.ColumnModel.getColumnIndices();
+            [columnLabels, visibleVariableNames] = obj.ColumnModel.getColumnNames();
+            columnLabels = string(columnLabels);
+            visibleVariableNames = string(visibleVariableNames);
+            columnWidths = obj.ColumnModel.getColumnWidths();
+            columnEditable = obj.getVisibleColumnEditable();
+
+            columnSpecs = entitytable.ColumnSpec.empty(1, 0);
+            for i = 1:numel(variableNames)
+                visibleIdx = find(visibleColumns == i, 1, 'first');
+                isVisible = ~isempty(visibleIdx);
+
+                if isVisible
+                    displayName = columnLabels(visibleIdx);
+                    if obj.isColumnFilterActive(variableNames(i))
+                        displayName = "* " + displayName;
+                    end
+                    width = columnWidths(visibleIdx);
+                    isEditable = columnEditable(visibleIdx);
+                    order = visibleIdx;
+                else
+                    nameIdx = find(visibleVariableNames == variableNames(i), 1, 'first');
+                    if isempty(nameIdx)
+                        displayName = variableNames(i);
+                    else
+                        displayName = columnLabels(nameIdx);
+                    end
+                    width = "auto";
+                    isEditable = false;
+                    order = numel(variableNames) + i;
+                end
+
+                columnSpecs(1, end+1) = entitytable.ColumnSpec(variableNames(i), ...
+                    DisplayName=displayName, Visible=isVisible, Width=width, ...
+                    Order=order, IsEditable=isEditable, ...
+                    Options=obj.getOptionsForVariable(variableNames(i)), ...
+                    TooltipFcn=obj.getTooltipFcnForVariable(variableNames(i)), ...
+                    UserData=obj.getEntityTableColumnUserData(i)); %#ok<AGROW>
+            end
+
+            columnSpecs(1, end+1) = entitytable.ColumnSpec( ...
+                string(obj.RowKeyVariableName), Visible=false, ...
+                Width=1, Order=numel(variableNames) + 1);
+        end
+
+        function applySystemFilters(obj)
+            if isempty(obj.EntityTableView) || ~isvalid(obj.EntityTableView) || isempty(obj.MetaTable)
+                return
+            end
+
+            obj.applyExternalRowFilter()
+            obj.applyIgnoredRowsFilter()
+            obj.notifyTableRowsUpdated()
+        end
+
+        function applyExternalRowFilter(obj)
+            if isempty(obj.ExternalFilterMap)
+                obj.EntityTableView.clearFilter(obj.RowKeyVariableName)
+                return
+            end
+
+            visibleRows = find(obj.ExternalFilterMap);
+            obj.EntityTableView.setFilter(obj.RowKeyVariableName, ...
+                entitytable.FilterSpec.setMembership(obj.RowKeyVariableName, visibleRows))
+        end
+
+        function applyIgnoredRowsFilter(obj)
+            ignoreVariableName = obj.getIgnoreVariableName();
+            if ignoreVariableName == ""
+                return
+            end
+
+            if obj.ShowIgnoredEntries
+                obj.EntityTableView.clearFilter(ignoreVariableName)
+            else
+                obj.EntityTableView.setFilter(ignoreVariableName, ...
+                    entitytable.FilterSpec(ignoreVariableName, "custom", ...
+                    Value=@(value) obj.isNotIgnoredValue(value)))
+            end
+        end
+
+        function tf = isSystemFilterVariable(obj, variableName)
+            variableName = string(variableName);
+            tf = variableName == string(obj.RowKeyVariableName);
+            ignoreVariableName = obj.getIgnoreVariableName();
+            if ignoreVariableName ~= "" && variableName == ignoreVariableName && ~obj.ShowIgnoredEntries
+                tf = true;
+            end
+        end
+
+        function tf = isColumnFilterActive(obj, variableName)
+            tf = any(obj.ActiveColumnFilterNames == string(variableName));
+        end
+
+        function setColumnFilterActive(obj, variableName, isActive)
+            variableName = string(variableName);
+            if variableName == "" || obj.isSystemFilterVariable(variableName)
+                return
+            end
+
+            if isActive
+                obj.ActiveColumnFilterNames = unique([obj.ActiveColumnFilterNames, variableName], 'stable');
+            else
+                obj.ActiveColumnFilterNames(obj.ActiveColumnFilterNames == variableName) = [];
+            end
+
+            obj.updateColumnFilterState()
+        end
+
+        function updateColumnFilterState(obj)
+            variableNames = string(obj.MetaTableVariableNames);
+            active = ismember(variableNames, obj.ActiveColumnFilterNames);
+
+            obj.ColumnFilterActive = active(:);
+            if ~isempty(obj.ColumnFilter) && isvalid(obj.ColumnFilter)
+                obj.ColumnFilter.setActiveVariableNames(obj.ActiveColumnFilterNames)
+            end
+
+            obj.syncEntityTableColumnSpecs()
+        end
+
+        function variableName = getIgnoreVariableName(obj)
+            variableNames = string(obj.MetaTableVariableNames);
+            matchIdx = find(contains(lower(variableNames), 'ignore'), 1, 'first');
+            if isempty(matchIdx)
+                variableName = "";
+            else
+                variableName = variableNames(matchIdx);
+            end
+        end
+
+        function tf = isNotIgnoredValue(~, value)
+            if isempty(value)
+                tf = true;
+            elseif islogical(value)
+                tf = ~value;
+            else
+                tf = ~strcmpi(string(value), "true");
+            end
+        end
+
+        function editable = getVisibleColumnEditable(obj)
+            visibleColumns = obj.ColumnModel.getColumnIndices();
+            if isempty(visibleColumns)
+                editable = [];
+                return
+            end
+
+            editable = obj.ColumnModel.getColumnIsEditable;
+            [~, variableNames] = obj.ColumnModel.getColumnNames();
+            variableNames = string(variableNames);
+
+            if ~isempty(obj.MetaTableVariableAttributes)
+                attributeNames = string({obj.MetaTableVariableAttributes.Name});
+                [isMatched, attributeIdx] = ismember(variableNames, attributeNames);
+
+                isEditableAttribute = false(size(editable));
+                if any(isMatched)
+                    isEditableAttribute(isMatched) = ...
+                        [obj.MetaTableVariableAttributes(attributeIdx(isMatched)).IsEditable];
+                end
+                editable = editable & isEditableAttribute;
+
+                hasOptions = false(size(editable));
+                if any(isMatched)
+                    matchedAttributes = obj.MetaTableVariableAttributes(attributeIdx(isMatched));
+                    hasOptions(isMatched) = [matchedAttributes.HasOptions] & ...
+                        strcmpi({matchedAttributes.TableType}, obj.MetaTableType);
+                end
+                editable = editable | hasOptions;
+            end
+
+            columnNames = obj.ColumnModel.getColumnNames();
+            if obj.AllowTableEdits
+                editable(contains(lower(columnNames), 'ignore')) = true;
+                editable(contains(lower(columnNames), 'description')) = true;
+            else
+                editable(:) = false;
+            end
+        end
+
+        function columnFormat = getVisibleColumnFormat(obj, visibleColumns)
+            columnFormat = repmat({'char'}, 1, numel(visibleColumns));
+            if isempty(visibleColumns) || isempty(obj.MetaTableCell) || size(obj.MetaTableCell, 1) == 0
+                return
+            end
+
+            C = obj.MetaTableCell(:, visibleColumns);
+            firstRow = C(1, :);
+
+            isNumeric = cellfun(@(value) isnumeric(value) && ...
+                (isscalar(value) || isempty(value)), firstRow, 'UniformOutput', true);
+            columnFormat(isNumeric) = {'numeric'};
+
+            isLogical = cellfun(@(value) islogical(value) && ...
+                (isscalar(value) || isempty(value)), firstRow, 'UniformOutput', true);
+            columnFormat(isLogical) = {'logical'};
+
+            if ~isempty(obj.MetaTable)
+                T = obj.MetaTable(1, visibleColumns);
+                isEnumeration = cellfun(@(value) isenum(value), table2cell(T), 'UniformOutput', true);
+                for i = find(isEnumeration)
+                    enumObject = T{1, i};
+                    if iscell(enumObject)
+                        enumObject = enumObject{1};
+                    end
+                    [~, enumNames] = enumeration(enumObject);
+                    columnFormat{i} = enumNames;
+                end
+
+                isCategorical = cellfun(@(value) iscategorical(value), table2cell(T), 'UniformOutput', true);
+                for i = find(isCategorical)
+                    categoricalObject = T{1, i};
+                    if iscell(categoricalObject)
+                        categoricalObject = categoricalObject{1};
+                    end
+                    if isprotected(categoricalObject)
+                        columnFormat{i} = categories(categoricalObject);
+                    else
+                        columnFormat{i} = cat(1, '<undefined>', categories(categoricalObject));
+                    end
+                end
+            end
+
+            [~, variableNames] = obj.ColumnModel.getColumnNames();
+            variableNames = string(variableNames);
+            for i = 1:numel(variableNames)
+                options = obj.getOptionsForVariable(variableNames(i));
+                if isempty(options)
+                    continue
+                end
+                columnFormat{i} = obj.normalizeColumnOptions(options);
+            end
+        end
+
+        function options = getOptionsForVariable(obj, variableName)
+            options = [];
+            if isempty(obj.MetaTableVariableAttributes)
+                return
+            end
+
+            attributeNames = string({obj.MetaTableVariableAttributes.Name});
+            tableTypes = string({obj.MetaTableVariableAttributes.TableType});
+            hasOptions = [obj.MetaTableVariableAttributes.HasOptions];
+            matchIdx = find(attributeNames == string(variableName) & ...
+                strcmpi(tableTypes, obj.MetaTableType) & hasOptions, 1, 'first');
+
+            if ~isempty(matchIdx)
+                options = obj.MetaTableVariableAttributes(matchIdx).OptionsList;
+            end
+        end
+
+        function tooltipFcn = getTooltipFcnForVariable(obj, variableName)
+            tooltipFcn = [];
+            if isempty(obj.MetaTableVariableAttributes)
+                return
+            end
+
+            attributeNames = string({obj.MetaTableVariableAttributes.Name});
+            tableTypes = string({obj.MetaTableVariableAttributes.TableType});
+            matchIdx = find(attributeNames == string(variableName) & ...
+                strcmpi(tableTypes, obj.MetaTableType), 1, 'first');
+            if isempty(matchIdx)
+                return
+            end
+
+            varAttr = obj.MetaTableVariableAttributes(matchIdx);
+            hasRendererFunction = isfield(varAttr, 'HasRendererFunction') && ...
+                varAttr.HasRendererFunction;
+            hasClassName = isfield(varAttr, 'ClassName') && ~isempty(varAttr.ClassName);
+            if hasRendererFunction && hasClassName
+                className = varAttr.ClassName;
+                tooltipFcn = @(value, ~) obj.getTableVariableTooltip(className, value);
+            end
+        end
+
+        function userData = getEntityTableColumnUserData(obj, columnIndex)
+            userData = struct();
+            if obj.UseHtmlTable && obj.isHtmlFormattedColumn(columnIndex)
+                userData.Renderer = "html";
+            end
+        end
+
+        function str = getTableVariableTooltip(~, className, value)
+            str = "";
+            try
+                tableVariableObj = feval(className, value);
+                str = string(tableVariableObj.getCellTooltipString());
+            catch
+            end
+        end
+
+        function options = normalizeColumnOptions(~, options)
+            if iscell(options) && isscalar(options) && iscell(options{1})
+                options = options{1};
+            end
+            if isstring(options)
+                options = cellstr(options);
+            end
+        end
+
+        function onMetaTableSet(obj, newTable)
+            if isa(newTable, 'nansen.metadata.MetaTable')
+                T = newTable.getFormattedTableData([], [], 'modern');
+                obj.MetaTableType = lower(newTable.getTableType());
+                obj.MetaTableCell = table2cell(T);
+            elseif isa(newTable, 'table')
+                obj.MetaTableCell = table2cell(newTable);
+            end
+
+            if ~isempty(obj.MetaTable)
+                obj.MetaTableVariableNames = obj.MetaTable.Properties.VariableNames;
+                obj.RowKeyVariableName = obj.getUniqueRowKeyVariableName(obj.MetaTableVariableNames);
+            else
+                obj.MetaTableVariableNames = {};
+                obj.RowKeyVariableName = 'NansenRowIndex__';
+            end
+
+            obj.MetaTableVariableAttributes = obj.getMetaTableVariableAttributes();
+        end
+
+        function onTableVariableAttributesFcnSet(obj)
+            obj.MetaTableVariableAttributes = obj.getMetaTableVariableAttributes();
+            if obj.IsConstructed
+                obj.updateColumnLayout()
+            end
+        end
+
+        function onTableFontSizeSet(obj)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable) && isprop(obj.HTable, 'FontSize')
+                obj.HTable.FontSize = obj.TableFontSize;
+            end
+        end
+
+        function onColumnFilterSet(obj)
+            if ~isempty(obj.FilterChangedListener)
+                delete(obj.FilterChangedListener)
+            end
+
+            obj.FilterChangedListener = addlistener(obj.ColumnFilter, ...
+                'FilterUpdated', @obj.onFilterUpdated);
+        end
+
+        function onFilterUpdated(obj, ~, ~)
+            obj.updateTableView([], false)
+            obj.notifyTableRowsUpdated()
+        end
+
+        function updateMetaTableVariableAttributes(obj)
+            obj.MetaTableVariableAttributes = obj.getMetaTableVariableAttributes();
+        end
+
+        function S = getMetaTableVariableAttributes(obj)
+            if isempty(obj.MetaTable)
+                S = struct.empty;
+            elseif ~isempty(obj.GetTableVariableAttributesFcn)
+                S = obj.GetTableVariableAttributesFcn(obj.MetaTableType);
+            else
+                S = obj.getDefaultMetaTableVariableAttributes();
+            end
+        end
+
+        function S = getDefaultMetaTableVariableAttributes(obj)
+            import nansen.metadata.abstract.TableVariable;
+
+            if isempty(obj.MetaTable)
+                S = struct.empty;
+                return
+            end
+
+            varNames = obj.MetaTable.Properties.VariableNames;
+            numVars = numel(varNames);
+            S = TableVariable.getDefaultTableVariableAttribute();
+            S = repmat(S, 1, numVars);
+
+            [S(1:numVars).Name] = varNames{:};
+            [S(1:numVars).TableType] = deal(obj.MetaTableType);
+        end
+
+        function value = normalizeDisplayValue(obj, value)
+            if ischar(value)
+                return
+            elseif isnumeric(value) || islogical(value)
+                if isscalar(value) || isempty(value)
+                    return
+                else
+                    value = mat2str(value);
+                end
+            else
+                value = obj.stringifyDisplayValue(value);
+            end
+        end
+
+        function str = stringifyDisplayValue(obj, value)
+            if isempty(value)
+                str = '';
+            elseif iscell(value)
+                str = obj.stringifyCellValue(value);
+            elseif isstring(value) || isdatetime(value) || isduration(value) || ...
+                    iscategorical(value) || isenum(value)
+                str = obj.stringifyStringConvertibleValue(value);
+            elseif isstruct(value)
+                str = strtrim(evalc('disp(value)'));
+            else
+                try
+                    str = char(value);
+                catch
+                    str = strtrim(evalc('disp(value)'));
+                end
+            end
+        end
+
+        function str = stringifyCellValue(obj, value)
+            if isempty(value)
+                str = '';
+                return
+            end
+
+            parts = cellfun(@obj.stringifyDisplayValue, value(:), ...
+                'UniformOutput', false);
+            str = char(strjoin(string(parts), ', '));
+        end
+
+        function str = stringifyStringConvertibleValue(~, value)
+            if isscalar(value)
+                str = char(value);
+            else
+                str = char(strjoin(string(value(:).'), ', '));
+            end
+        end
+
+        function onEntityCellEdited(obj, ~, evtData)
+            tableRowInd = evtData.ModelRow;
+            tableColInd = find(strcmp(obj.MetaTableVariableNames, evtData.VariableName), 1, 'first');
+            if isempty(tableRowInd) || isempty(tableColInd)
+                return
+            end
+
+            obj.MetaTableCell{tableRowInd, tableColInd} = evtData.NewValue;
+
+            if ~isempty(obj.CellEditCallback)
+                evt = uiw.event.EventData(...
+                    'Indices', [tableRowInd, tableColInd], ...
+                    'NewValue', evtData.NewValue, ...
+                    'PreviousValue', evtData.OldValue);
+                obj.CellEditCallback(obj.HTable, evt)
+            end
+        end
+
+        function onEntitySelectionChanged(obj, ~, ~)
+            selectedRows = obj.getSelectedEntries();
+            evtData = uiw.event.EventData('SelectedRows', selectedRows);
+            obj.notify('SelectionChanged', evtData)
+        end
+
+        function onModernDisplayDataChanged(obj, src, evt)
+            if obj.isDisplayDataInteraction(evt, "rearrange")
+                obj.captureColumnWidths()
+                obj.captureColumnOrder()
+                obj.syncEntityTableColumnSpecs()
+                obj.syncEntityTableContextMenus()
+                obj.clearDisplayColumnOrder(src)
+                return
+            end
+
+            if obj.isDisplayDataInteraction(evt, "resize")
+                obj.AutoAppliedColumnWidths = [];
+                obj.captureColumnWidths()
+                return
+            end
+
+            if obj.hasEventProperty(evt, 'DisplayRowName')
+                displayRowName = obj.getEventProperty(evt, 'DisplayRowName');
+                if ~isempty(displayRowName) && ...
+                        obj.EntityTableView.applyNativeDisplayRowNames(displayRowName)
+                    obj.notifyTableRowsUpdated()
+                    return
+                end
+            end
+
+            displayData = [];
+            if obj.hasEventProperty(evt, 'DisplayData')
+                displayData = obj.getEventProperty(evt, 'DisplayData');
+            elseif isprop(src, 'DisplayData')
+                displayData = src.DisplayData;
+            end
+
+            if obj.EntityTableView.applyNativeDisplayOrder(displayData)
+                obj.notifyTableRowsUpdated()
+            end
+        end
+
+        function onTableColumnWidthChanged(obj)
+            if obj.IsApplyingColumnWidths
+                return
+            end
+
+            obj.AutoAppliedColumnWidths = [];
+            obj.captureColumnWidths()
+        end
+
+        function onEntityColumnLayoutChanged(obj, ~, ~)
+            if obj.IsApplyingColumnWidths
+                return
+            end
+
+            obj.AutoAppliedColumnWidths = [];
+            obj.captureColumnWidths()
+            obj.captureColumnOrder()
+        end
+
+        function onEntityCellActivated(obj, src, evt)
+            if isempty(obj.MouseDoubleClickedFcn)
+                return
+            end
+
+            if isempty(evt.DisplayRow) || isempty(evt.DisplayColumn) || ...
+                    any([evt.DisplayRow, evt.DisplayColumn] == 0)
+                return
+            end
+
+            evtData = uiw.event.EventData(...
+                'Cell', [evt.DisplayRow, evt.DisplayColumn], ...
+                'SelectionType', 'open', ...
+                'Button', 1, ...
+                'Position', [0 0], ...
+                'MetaOn', false, ...
+                'ControlOn', false);
+
+            obj.MouseDoubleClickedFcn(src.getComponent(), evtData)
+        end
+
+        function onEntityFilterChanged(obj, ~, evt)
+            if isempty(evt.VariableName)
+                obj.ActiveColumnFilterNames = strings(1, 0);
+                obj.updateColumnFilterState()
+            else
+                obj.setColumnFilterActive(evt.VariableName, ~isempty(evt.FilterSpec))
+            end
+            obj.notifyTableRowsUpdated()
+        end
+
+        function notifyTableRowsUpdated(obj)
+            if isempty(obj.MetaTableCell)
+                rows = [];
+            else
+                rows = obj.DisplayedRows;
+            end
+            evtdata = uiw.event.EventData('RowIndices', rows, 'Type', 'TableFilterUpdate');
+            obj.notify('TableUpdated', evtdata)
+        end
+
+        function captureColumnWidths(obj)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable) || isempty(obj.ColumnModel)
+                return
+            end
+            if obj.IsApplyingColumnWidths
+                return
+            end
+
+            columnWidths = obj.getCurrentVisibleColumnWidths();
+            if isequal(columnWidths, obj.AutoAppliedColumnWidths)
+                return
+            end
+            if isequal(columnWidths, obj.ColumnModel.getColumnWidths())
+                return
+            end
+            if ~isempty(columnWidths)
+                obj.ColumnModel.setColumnWidths(columnWidths);
+            end
+        end
+
+        function columnWidths = getCurrentVisibleColumnWidths(obj)
+            columnWidths = [];
+            if ~isempty(obj.EntityTableView) && isvalid(obj.EntityTableView) && ...
+                    ismethod(obj.EntityTableView, 'getColumnWidths')
+                columnWidths = obj.EntityTableView.getColumnWidths();
+                columnWidths = obj.normalizeColumnWidths(columnWidths);
+            elseif ~isempty(obj.HTable) && isvalid(obj.HTable) && ...
+                    isprop(obj.HTable, 'ColumnWidth')
+                columnWidths = obj.normalizeColumnWidths(obj.HTable.ColumnWidth);
+            end
+            if isempty(columnWidths) && ~isempty(obj.ColumnModel) && isvalid(obj.ColumnModel)
+                columnWidths = obj.ColumnModel.getColumnWidths();
+                columnWidths = obj.normalizeColumnWidths(columnWidths);
+            end
+        end
+
+        function captureColumnOrder(obj)
+            if isempty(obj.HTable) || ~isvalid(obj.HTable) || isempty(obj.ColumnModel)
+                return
+            end
+            if ~isempty(obj.EntityTableView) && isvalid(obj.EntityTableView) && ...
+                    ismethod(obj.EntityTableView, 'getColumnVariableOrder')
+                newVariableOrder = obj.EntityTableView.getColumnVariableOrder();
+                [~, variableNames] = obj.ColumnModel.getColumnNames();
+                if ~isequal(newVariableOrder, string(variableNames))
+                    obj.ColumnModel.setNewColumnVariableOrder(newVariableOrder);
+                    if ~isempty(obj.ColumnFilter) && isvalid(obj.ColumnFilter)
+                        obj.ColumnFilter.hideFilters()
+                    end
+                end
+                return
+            end
+            if ~isprop(obj.HTable, 'DisplayColumnOrder')
+                return
+            end
+
+            displayColumnOrder = obj.HTable.DisplayColumnOrder;
+            if isempty(displayColumnOrder)
+                return
+            end
+
+            [~, variableNames] = obj.ColumnModel.getColumnNames();
+            if numel(displayColumnOrder) ~= numel(variableNames)
+                return
+            end
+
+            newVariableOrder = string(variableNames(displayColumnOrder));
+            if isequal(newVariableOrder, string(variableNames))
+                return
+            end
+
+            obj.ColumnModel.setNewColumnVariableOrder(newVariableOrder);
+            if ~isempty(obj.ColumnFilter) && isvalid(obj.ColumnFilter)
+                obj.ColumnFilter.hideFilters()
+            end
+        end
+
+        function columnWidths = normalizeColumnWidths(~, columnWidths)
+            if iscell(columnWidths)
+                parsedWidths = nan(1, numel(columnWidths));
+                for i = 1:numel(columnWidths)
+                    parsedWidths(i) = parseWidth(columnWidths{i});
+                end
+                if any(~isfinite(parsedWidths))
+                    columnWidths = [];
+                else
+                    columnWidths = parsedWidths;
+                end
+            elseif ~isnumeric(columnWidths)
+                columnWidths = parseWidth(columnWidths);
+                if ~isfinite(columnWidths)
+                    columnWidths = [];
+                end
+            else
+                columnWidths = double(columnWidths(:).');
+            end
+
+            function width = parseWidth(widthValue)
+                if isnumeric(widthValue) && isscalar(widthValue)
+                    width = double(widthValue);
+                    return
+                end
+                if isstring(widthValue) || ischar(widthValue)
+                    width = str2double(string(widthValue));
+                    if isempty(width) || isnan(width)
+                        width = NaN;
+                    end
+                    return
+                end
+                width = NaN;
+            end
+        end
+
+        function tf = isDisplayDataInteraction(obj, evt, interactionName)
+            tf = false;
+            if ~obj.hasEventProperty(evt, 'Interaction')
+                return
+            end
+
+            interaction = obj.getEventProperty(evt, 'Interaction');
+            interaction = lower(string(interaction));
+            interactionName = lower(string(interactionName));
+            tf = any(interaction == interactionName | contains(interaction, interactionName));
+        end
+
+        function tf = hasEventProperty(~, evt, propertyName)
+            tf = isprop(evt, propertyName) || ...
+                (isstruct(evt) && isfield(evt, propertyName));
+        end
+
+        function value = getEventProperty(~, evt, propertyName)
+            value = evt.(propertyName);
+        end
+
+        function clearDisplayColumnOrder(~, hTable)
+            if isempty(hTable) || ~isvalid(hTable) || ...
+                    ~isprop(hTable, 'DisplayColumnOrder')
+                return
+            end
+
+            try
+                hTable.DisplayColumnOrder = [];
+            catch
+            end
+        end
+
+        function rowKeyName = getUniqueRowKeyVariableName(~, variableNames)
+            rowKeyName = 'NansenRowIndex__';
+            while any(strcmp(variableNames, rowKeyName))
+                rowKeyName = [rowKeyName, '_']; %#ok<AGROW>
+            end
+        end
+    end
+
+    methods (Static)
+        function tf = isValidTableClass(var)
+            validClasses = nansen.ui.metatable.EntityTableMetaTableViewer.VALID_TABLE_CLASS;
+            tf = any(cellfun(@(type) isa(var, type), validClasses));
+        end
+    end
+end

--- a/code/+nansen/+ui/+metatable/EntityTableMetaTableViewer.m
+++ b/code/+nansen/+ui/+metatable/EntityTableMetaTableViewer.m
@@ -795,8 +795,7 @@ classdef EntityTableMetaTableViewer < handle
 
         function position = getParentContentPixelPosition(obj)
             parent = obj.HTable.Parent;
-            if isa(parent, 'matlab.ui.container.Tab') ...
-                    && exist('uim.utility.getContentPixelPosition', 'file') == 2
+            if isa(parent, 'matlab.ui.container.Tab')
                 position = uim.utility.getContentPixelPosition(parent);
             elseif isprop(parent, 'Position')
                 position = [0, 0, parent.Position(3:4)];

--- a/code/+nansen/+ui/+metatable/LegacyJavaMetaTableViewer.m
+++ b/code/+nansen/+ui/+metatable/LegacyJavaMetaTableViewer.m
@@ -1,0 +1,1652 @@
+classdef LegacyJavaMetaTableViewer < handle & uiw.mixin.AssignPVPairs
+%MetaTableViewer Implementation of UI table for viewing metadata tables.
+%
+%   This class is built around the Table class from the Widgets Toolbox.
+%   This is a very responsive java based table implementation. This class
+%   extends the functionality of the uiw.widget.Table in primarily two
+%   ways:
+%       1) Columns can be filtered
+%       2) Settings for columns are saved until next time table is opened.
+%           (Columns widths, column visibility and column label is saved
+%           across matlab sessions) Todo: Also save column editable...
+
+% - - - - - - - - - - - - - - - TODO - - - - - - - - - - - - - - - - -
+    %  *[ ] Update table without emptying data! Use add column/remove
+    %   [ ] jTable.setPreserveSelectionsAfterSorting(true); Is this useful
+    %       here???
+    %   [ ] Save table settings to project folder
+
+    %       column from the java column model when hiding/showing columns
+    %   [ ] Outsource everything column related to column model
+    %   [ ] Create table with all columns and store the tablecolumn objects in the column model if rows are hidden?
+    %
+    %   [x] Make ignore column editable
+    %   [x] Set method for metaTable...
+    %   [x] Revert change from metatable. need to get formatted data from
+    %       table!
+    %   [ ] Should the filter be a RowModel?
+    %   [ ] Make method for getting colorcoded column names (based on
+    %   column filters, and always run columnNames through this method
+    %   before setting the on the table object
+    %   [ ] Will ColumnFilter.isColumnFilterActive always match the columns
+    %       in the column model? Need to verify
+    %   [ ] Straighten out what to do about the MetaTable property.
+    %       Problem: if the input metatable was a MetaTable object, it
+    %       might contain data which is not renderable in the uitable, i.e
+    %       structs. If table data is changed, and data is put back into
+    %       the table version of the MetaTable, the set.MetaTable methods
+    %       creates a downstream bug because it sets it, and consequently
+    %       the MetaTableCell property without getting formatted data from
+    %       the metatable class. For now, I keep as it is, because the only
+    %       column I edit is the ignore column, and the MetaTable property
+    %       is not used anywhere. But this can be a BIG PROBLEM if things
+    %       change some time.
+
+% - - - - - - - - - - - - - - PROPERTIES - - - - - - - - - - - - - - -
+
+    properties (Constant, Hidden)
+        VALID_TABLE_CLASS = {'nansen.metadata.MetaTable', 'table'};
+    end
+
+    properties % Table preferences
+        ShowIgnoredEntries = true
+        AllowTableEdits = true
+        TableFontSize = 12
+        MetaTableType = 'session' %Note: should always be lowercase
+    end
+
+    properties
+        SelectedEntries         % Selected rows from full table, irrespective of sorting and filtering.
+        CellEditCallback
+        KeyPressCallback
+
+        MouseDoubleClickedFcn = [] % This should be internalized, but for now it is assigned from session browser/nansen
+
+        DeleteColumnFcn = []    % This should be internalized, but for now it is assigned from session browser/nansen
+        UpdateColumnFcn = []    % This should be internalized, but for now it is assigned from session browser/nansen
+        ResetColumnFcn = []     % This should be internalized, but for now it is assigned from session browser/nansen
+        EditColumnFcn = []      % This should be internalized, but for now it is assigned from session browser/nansen
+
+        % Does this make sense? Thinking that this should be taken care of
+        % at another level, as the Metatable viewer is not nansen specific...
+        GetTableVariableAttributesFcn = [] % Function handle for retrieving table variable attributes.
+    end
+
+    properties (SetAccess = private, SetObservable = true)
+        MetaTable               % Table version of the table data
+        MetaTableCell cell      % Cell array version of the table data
+        MetaTableVariableNames  % Cell array of variable names in full table
+        MetaTableVariableAttributes % Struct with attributes of metatable variables.
+    end
+
+    properties (Dependent)
+        ColumnSettings
+
+        % DisplayedRows - Rows of the original metatable which are
+        % currently displayed
+        DisplayedRows
+
+        % DisplayedColumns - Columns of the original metatable which are
+        % currently displayed (not implemented yet)
+        % DisplayedColumns
+    end
+
+    properties (SetAccess = private)
+        ColumnModel             % Class instance for updating columns based on user preferences.
+        ColumnFilter            % Class instance for filtering data based on column variables.
+    end
+
+    properties %(Access = private)
+
+        AppRef
+        Parent
+        HTable
+        JTable
+
+        ColumnContextMenu = []
+        TableContextMenu = []
+
+        DataFilterMap = []  % Boolean "map" (numRows x numColumns) with false for cells that is outside filter range
+        ExternalFilterMap = [] % Boolean vector with rows that are "filtered" externally. Todo: Formalize this better.
+        FilterChangedListener event.listener
+
+        ColumnWidthChangedListener
+        ColumnsRearrangedListener
+        MouseDraggedInHeaderListener
+
+        ColumnPressedTimer
+    end
+
+    properties (Access = private)
+        ColumnSettings_
+        lastMousePressTic
+        IsConstructed = false;
+        RequireReset = false;
+    end
+
+    events
+        TableUpdated
+        SelectionChanged
+    end
+
+% - - - - - - - - - - - - - - - METHODS - - - - - - - - - - - - - - -
+
+    methods % Structors
+
+        function obj = LegacyJavaMetaTableViewer(varargin)
+        %MetaTableViewer Construct for MetaTableViewer
+
+            % Take care of input arguments.
+            obj.parseInputs(varargin)
+
+            %if ~isempty(obj.ColumnSettings)
+                nvPairs = {'ColumnSettings', obj.ColumnSettings};
+            %else
+            %    nvPairs = {};
+            %end
+
+            % Initialize the column model.
+            obj.ColumnModel = nansen.ui.MetaTableColumnLayout(obj, nvPairs{:});
+
+            obj.createUiTable()
+
+            obj.ColumnFilter = nansen.ui.MetaTableColumnFilter(obj, obj.AppRef);
+
+            obj.IsConstructed = true;
+
+            if ~isempty(obj.MetaTableCell)
+                obj.refreshTable()
+                obj.HTable.Visible = 'on'; % Make table visible
+                drawnow
+            end
+        end
+
+        function delete(obj)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable)
+                columnWidths = obj.HTable.ColumnWidth;
+                if ~isempty(columnWidths)
+                    obj.ColumnModel.setColumnWidths(columnWidths);
+                end
+
+                delete(obj.ColumnModel)
+                delete(obj.HTable)
+            end
+        end
+    end
+
+    methods % Set/get
+
+        function rowIndices = get.DisplayedRows(obj)
+            if ~isempty(obj.ExternalFilterMap)
+                visibleRows = find( obj.ExternalFilterMap );
+            else
+                visibleRows = 1:size(obj.MetaTableCell, 1);
+            end
+
+            rowIndices = obj.getCurrentRowSelection();
+            rowIndices = intersect(rowIndices, visibleRows, 'stable');
+        end
+
+        function set.MetaTable(obj, newTable)
+        % Set method for metatable.
+        %
+        % 1) If the newValue is a MetaTable object, the table data is
+        %    retrieved before updating the property.
+        % 2) After new value is set it is passed on the onMetaTableSet
+        %    method which will also update the metaTableCell property and
+        %    update the ui table.
+
+            if isa(newTable, 'nansen.metadata.MetaTable')
+                obj.MetaTable = newTable.entries;
+            elseif isa(newTable, 'table')
+                obj.MetaTable = newTable;
+            else
+                error('New value of MetaTable property must be a MetaTable or a table object')
+            end
+
+            obj.onMetaTableSet(newTable)
+        end
+
+        function set.MetaTableType(obj, newValue)
+            oldType = obj.MetaTableType;
+            obj.MetaTableType = lower(newValue);
+            obj.onMetaTableTypeSet(oldType, lower(newValue))
+        end
+
+        function set.ColumnSettings(obj, newSettings)
+            if isempty(obj.ColumnModel)
+                obj.ColumnSettings_ = newSettings;
+            else
+                obj.ColumnModel.replaceColumnSettings(newSettings);
+                obj.updateColumnLayout()
+            end
+        end
+        function colSettings = get.ColumnSettings(obj)
+            if isempty(obj.ColumnModel)
+                colSettings = obj.ColumnSettings_;
+            else
+                colSettings = obj.ColumnModel.settings;
+            end
+        end
+
+        function set.ColumnFilter(obj, newValue)
+            obj.ColumnFilter = newValue;
+            if ~isempty(newValue)
+                obj.onColumnFilterSet()
+            end
+        end
+
+        function set.ShowIgnoredEntries(obj, newValue)
+
+            assert(islogical(newValue), 'Value for ShowIgnoredEntries must be a boolean')
+            obj.ShowIgnoredEntries = newValue;
+
+            obj.refreshTable()
+        end
+
+        function set.AllowTableEdits(obj, newValue)
+
+            assert(islogical(newValue), 'Value for AllowTableEdits must be a boolean')
+            obj.AllowTableEdits = newValue;
+
+            obj.updateColumnEditable()
+        end
+
+        function set.TableFontSize(obj, newValue)
+            obj.TableFontSize = newValue;
+            obj.onTableFontSizeSet()
+        end
+
+        function set.KeyPressCallback(obj, newValue)
+
+        end
+
+        function set.GetTableVariableAttributesFcn(obj, newValue)
+            obj.GetTableVariableAttributesFcn = newValue;
+            obj.onTableVariableAttributesFcnSet()
+        end
+    end
+
+    methods % Public methods
+
+        function refreshColumnModel(obj, varargin)
+        %refreshColumnModel Refresh the columnmodel
+        %
+        %   Note: This method should be called whenever a new metatable is
+        %   set, and whenever a metatable variable definition is changed.
+        %
+        %   Todo: {Find a way to make this happen when it is needed, instead
+        %   of requiring this method to be called explicitly. This fix need
+        %   to be implemented on the class (table model) owning the
+        %   columnmodel}
+
+            obj.ColumnModel.updateColumnEditableState()
+        end
+
+        function resetTable(obj, resetView)
+
+            % Note: There is an option here to not reset the table view,
+            % This is useful for aethetic reasons, to prevent flickering
+            % when updating a table.
+            if nargin < 2
+                resetView = true; % todo: make nv pair args
+            end
+
+            obj.MetaTable = table.empty;
+
+            if resetView
+                obj.refreshTable(table.empty, true)
+            end
+        end
+
+        function resetColumnFilters(obj)
+            obj.ColumnFilter.resetFilters()
+        end
+
+        function updateCells(obj, rowIdxData, colIdxData, newData)
+        %updateCells Update subset of cells...
+
+            % Note: The uiw.widget.Table setCell method takes the java
+            % table model's row order into account when inserting data into
+            % cells, but not the column order. That's why the rearrangement
+            % of rows and columns below are not equivalent
+
+            % Place new data in the cell representation of the metatable.
+            obj.MetaTableCell(rowIdxData, colIdxData) = newData;
+
+            % Get indices of visible rows based on data filter states
+            rowIdxVisible = obj.getCurrentRowSelection();
+
+            % Get indices of visible columns based on user selection of which columns to display
+            colIdxVisible = obj.getCurrentColumnSelection();
+
+            % Rearrange rows taking the table sorting into account:
+            if ~isempty(obj.HTable.RowSortIndex)
+                rowIdxVisible = rowIdxVisible(obj.HTable.RowSortIndex);
+            end
+
+            % Get the current order of column indices from java's column model
+            [colIdxJava, ~] = obj.ColumnModel.getColumnModelIndexOrder();
+
+            %Todo: Is it still a possibility that these are not the same length?
+            %colIdxVisible = colIdxVisible(colIdxJava);
+
+            % Get the indices for where to insert data in the uitable, i.e
+            % find which index of the visible data that corresponds with
+            % the index of the actual data.
+            [~, rowIdxUiTable, rowIdxDataSubset] = intersect(rowIdxVisible, rowIdxData, 'stable');
+            [~, colIdxUiTable, colIdxDataSubset] = intersect(colIdxVisible, colIdxData, 'stable');
+
+            % Insert data into the table model cell by cell
+            for i = 1:numel(rowIdxUiTable)
+                for j = 1:numel(colIdxUiTable)
+                    % Get indices for current uitable cell
+                    iRow = rowIdxUiTable(i);
+                    jCol = colIdxJava( colIdxUiTable(j) ); % Reorder based on the underlying column order of the java model because this is not done internally in setCell
+                    % Get value of data for current cell
+                    thisValue = newData(rowIdxDataSubset(i), colIdxDataSubset(j));
+                    % Insert value
+                    obj.HTable.setCell(iRow, jCol, thisValue)
+                end
+            end
+            drawnow
+        end
+
+        function updateTableRow(obj, rowIdxData, tableRowData)
+        %updateTableRow Update data of specified table row
+            % Count number of columns and get column indices
+            colIdx = 1:size(tableRowData, 2);
+
+            if isa(tableRowData, 'table')
+                newData = table2cell(tableRowData);
+            elseif isa(tableRowData, 'cell')
+                %pass
+            else
+                error('Table row data is in the wrong format')
+            end
+
+            % Refresh cells of ui table...
+            obj.updateCells(rowIdxData, colIdx, newData)
+        end
+
+        function updateFormattedTableColumnData(obj, columnName, columnData)
+        %reformatTableColumnData Reformat data for specified column
+            columnIndex = find(strcmp(obj.MetaTable.Properties.VariableNames, columnName));
+            obj.MetaTableCell(:, columnIndex) = table2cell(columnData);
+        end
+
+        function appendTableRow(obj, rowData)
+            % Would be neat, but haven't found a way to do it.
+        end
+
+        function updateVisibleRows(obj, rowInd)
+
+            [numRows, ~] = size(obj.MetaTable);
+            obj.ExternalFilterMap = false(numRows, 1);
+            obj.ExternalFilterMap(rowInd) = true;
+
+            obj.updateTableView(rowInd)
+        end
+
+        function refreshTable(obj, newTable, flushTable)
+        %refreshTable Method for refreshing the table
+
+            % TODO: Make sure the selection is maintained.
+
+            % Note: If [] is provided as 2nd arg, the table is not reset.
+            % This might be used in some cases where the table should be
+            % kept, but the flushTable flag is provided.
+
+            requireReset = isempty( obj.MetaTable ) || obj.RequireReset;
+
+            if nargin >= 2 && ~(isnumeric(newTable) && isempty(newTable))
+                obj.MetaTable = newTable;
+            end
+
+            if nargin < 3 || isempty(flushTable)
+                flushTable = requireReset;
+            end
+
+            % Todo: Save selection
+            %selectedEntries = obj.getSelectedEntries();
+
+            if flushTable % Empty table, gives smoother update in some cases
+                obj.HTable.Data = {};
+                obj.DataFilterMap = []; % reset data filter map
+                if ~isempty(obj.MetaTable)
+                    obj.ColumnFilter.onMetaTableChanged()
+                end
+                obj.RequireReset = false;
+            else
+                if ~isempty(obj.ColumnFilter)
+                    obj.ColumnFilter.onMetaTableUpdated()
+                end
+            end
+
+            drawnow
+            if ~isempty(obj.MetaTable)
+                obj.updateMetaTableVariableAttributes()
+                obj.updateColumnLayout()
+                obj.updateTableView()
+            else
+                obj.HTable.ColumnName = cell(1,0);
+            end
+            drawnow
+            % Todo: Restore selection
+            %obj.setSelectedEntries(selectedEntries);
+        end
+
+        function replaceTable(obj, newTable)
+            obj.MetaTable = newTable;
+            obj.ColumnFilter.onMetaTableChanged()
+            obj.updateTableView()
+        end
+
+        function rowInd = getMetaTableRows(obj, rowIndDisplay)
+
+            % Todo: Determine if this method is useful in
+            % getSelectedEntries/setSelectedEntries?
+            dataInd = get(obj.HTable.JTable.Model, 'Indexes');
+
+            if ~isempty(dataInd)
+                rowInd = dataInd(rowIndDisplay)+1; % +1 because java indices start at 0
+            else
+                rowInd = rowIndDisplay;
+            end
+
+            % Get currently visible row and column indices.
+            visibleRowInd = obj.getCurrentRowSelection();
+
+            % Get row and column indices for original data (unfiltered, unsorted, allcolumns)
+            rowInd = visibleRowInd(rowInd);
+
+            % Make sure output is a column vector
+            if iscolumn(rowInd)
+                rowInd = transpose(rowInd);
+            end
+        end
+
+        function IND = getSelectedEntries(obj)
+        %getSelectedEntries Get selected entries based on the MetaTable
+        %
+        %   Get selected entry from original metatable taking column
+        %   sorting and filtering into account.
+
+            IND = obj.HTable.SelectedRows;
+
+            dataInd = get(obj.HTable.JTable.Model, 'Indexes');
+
+            if ~isempty(dataInd)
+                IND = dataInd(IND)+1; % +1 because java indices start at 0
+                IND = transpose( double( sort(IND) ) ); % return as row vector
+            else
+                IND = IND;
+            end
+
+            % Get currently visible row and column indices.
+            visibleRowInd = obj.getCurrentRowSelection();
+
+            % Get row and column indices for original data (unfiltered, unsorted, allcolumns)
+            IND = visibleRowInd(IND);
+        end
+
+        function setSelectedEntries(obj, IND, preventCallback)
+        %setSelectedEntries Set row selection
+
+            if nargin < 3
+                preventCallback = false; % todo: make nv pair args
+            end
+
+            % Get currently visible row indices.
+            visibleRowInd = obj.getCurrentRowSelection();
+
+            % Get row indices based on the underlying table model (taking sorting into account)
+            dataInd = get(obj.HTable.JTable.Model, 'Indexes') + 1;
+            if isempty(dataInd)
+                dataInd = 1:numel(visibleRowInd);
+            end
+
+            % Reorder the visible row indices according to possible sort
+            % order
+            visibleRowInd = visibleRowInd(dataInd);
+
+            % Find the rownumber corresponding to the given entries.
+            selectedRows = find(ismember(visibleRowInd, IND));
+
+            % Set the row selection
+            if preventCallback
+                obj.HTable.disableCallbacks();
+                obj.HTable.SelectedRows = selectedRows;
+                drawnow
+                obj.HTable.enableCallbacks();
+            else
+                obj.HTable.SelectedRows = selectedRows;
+            end
+        end
+
+        function [columnNames,variableNames] = getColumnNames(obj, columnIndices)
+        % getColumnNames - Get name of column(s) given column indices
+            if nargin < 2; columnIndices = []; end
+
+            [columnNames,variableNames] = obj.ColumnModel.getColumnNames();
+            if ~isempty(columnIndices)
+                columnNames = columnNames(columnIndices);
+                variableNames = variableNames(columnIndices);
+            end
+            if numel(columnNames) == 1 && iscell(columnNames)
+                columnNames = columnNames{1};
+                variableNames = variableNames{1};
+            end
+        end
+    end
+
+    methods (Access = private) % Create components
+
+        function parseInputs(obj, listOfArgs)
+         %parseInputs Input parser that checks for expected input classes
+
+            [nvPairs, remainingArgs] = utility.getnvpairs(listOfArgs);
+
+            % Need to set name value pairs first
+            obj.assignPVPairs(nvPairs{:})
+
+            if isempty(remainingArgs);    return;    end
+
+            % Check if first argument is a graphical container
+            % Todo: check that graphical object is an actual container...
+            if isgraphics(remainingArgs{1})
+                obj.Parent = remainingArgs{1};
+                remainingArgs = remainingArgs(2:end);
+            end
+
+            if isempty(remainingArgs);    return;    end
+
+            % Check if first argument in list is a valid metatable class
+            if obj.isValidTableClass( remainingArgs{1} )
+                obj.MetaTable = remainingArgs{1};
+                remainingArgs = remainingArgs(2:end);
+            end
+
+            if isempty(remainingArgs);    return;    end
+
+        end
+
+        function createUiTable(obj)
+
+            for i = 1:2
+
+                try
+                    obj.HTable = uim.widget.StylableTable(...
+                        'Parent', obj.Parent,...
+                        'Tag','MetaTable',...
+                        'Editable', true, ...
+                        'RowHeight', 30, ...
+                        'FontSize', obj.TableFontSize, ...
+                        'FontName', 'helvetica', ...
+                        'FontName', 'avenir next', ...
+                        'SelectionMode', 'discontiguous', ...
+                        'Sortable', true, ...
+                        'Units','normalized', ...
+                        'Position',[0 0.0 1 1], ...
+                        'HeaderPressedCallback', @obj.onMousePressedInHeader, ...
+                        'HeaderReleasedCallback', @obj.onMouseReleasedFromHeader, ...
+                        'MouseClickedCallback', @obj.onMousePressedInTable, ...
+                        'Visible', 'off', ...
+                        'BackgroundColor', [1,1,0.5]);
+                    break
+
+                catch ME
+                    switch ME.identifier
+                        case 'MATLAB:Java:ClassLoad'
+                            nansen.internal.setup.addUiwidgetsJarToJavaClassPath()
+                        otherwise
+                            rethrow(ME)
+                    end
+                end
+            end
+
+            if isempty(obj.HTable)
+                tf = nansen.internal.setup.isUiwidgetsOnJavapath();
+                if ~tf
+                    error('Failed to create the gui. Try to install to Widgets Toolbox v1.3.330 again')
+                else
+                    error('Nansen:MetaTableViewer:CorruptedJavaPath', ...
+                        'uiwidget jar is on javapath, but table creation failed.')
+                end
+            end
+
+            obj.HTable.CellEditCallback = @obj.onCellValueEdited;
+            obj.HTable.CellSelectionCallback = @obj.onCellSelectionChanged;
+            obj.HTable.JTable.getTableHeader().setReorderingAllowed(true);
+            obj.JTable = obj.HTable.JTable;
+
+            % Listener that detects if column widths change if user drags
+            % column headers edges to resize columns.
+            obj.ColumnWidthChangedListener = listener(obj.HTable, ...
+                'ColumnWidthChanged', @obj.onColumnWidthChanged);
+
+            obj.ColumnsRearrangedListener = listener(obj.HTable, ...
+                'ColumnsRearranged', @obj.onColumnsRearranged);
+
+            obj.MouseDraggedInHeaderListener = listener(obj.HTable, ...
+                'MouseDraggedInHeader', @obj.onMouseDraggedInTableHeader);
+
+            obj.HTable.Theme = uim.style.tableLight;
+
+        end
+
+        function createColumnContextMenu(obj)
+        %createColumnContextMenu Create a context menu for columns
+
+        % Note: This context menu is reused for all columns, but because
+        % it's appearance might depend on the column it is opened above,
+        % some changes are done in the method openColumnContextMenu before
+        % it is made visible. Also, a callback function is set there.
+
+            hFigure = ancestor(obj.Parent, 'figure');
+
+            % Create a context menu item for each of the different column
+            % formats.
+
+            obj.ColumnContextMenu = uicontextmenu(hFigure);
+
+            % Create items of the menu for columns of char type
+            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Sort A-Z');
+            hTmp.Tag = 'Sort Ascend';
+
+            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Sort Z-A');
+            hTmp.Tag = 'Sort Descend';
+
+% %             hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Filter...');
+% %             hTmp.Tag = 'Filter';
+% %             hTmp.Separator = 'on';
+
+            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Reset Filters');
+            hTmp.Tag = 'Reset Filters';
+            hTmp.Separator = 'on';
+
+            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Hide this column');
+            hTmp.Tag = 'Hide Column';
+            hTmp.Separator = 'on';
+
+            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Column settings...');
+            hTmp.Tag = 'ColumnSettings';
+            hTmp.MenuSelectedFcn = @(s,e) obj.ColumnModel.editSettings;
+
+            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Update column data');
+            hTmp.Separator = 'on';
+            hTmp.Tag = 'Update Column';
+
+              hSubMenu = uimenu(hTmp, 'Label', 'Update selected rows');
+              hSubMenu.Tag = 'Update selected rows';
+              hSubMenu = uimenu(hTmp, 'Label', 'Update all rows');
+              hSubMenu.Tag = 'Update all rows';
+
+              hSubMenu = uimenu(hTmp, 'Label', 'Reset selected rows', 'Separator', 'on');
+              hSubMenu.Tag = 'Reset selected rows';
+              hSubMenu = uimenu(hTmp, 'Label', 'Reset all rows');
+              hSubMenu.Tag = 'Reset all rows';
+
+              hSubMenu = uimenu(hTmp, 'Label', 'Edit tablevar function', 'Separator', 'on');
+              hSubMenu.Tag = 'Edit tablevar function';
+
+            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Delete this column');
+            hTmp.Tag = 'Delete Column';
+
+        end
+
+        function createColumnFilterComponents(obj)
+            % todo
+        end
+    end
+
+    methods (Access = {?nansen.ui.metatable.LegacyJavaMetaTableViewer, ?nansen.ui.MetaTableColumnLayout, ?nansen.ui.MetaTableColumnFilter})
+
+        function updateTableView(obj, visibleRows, requestFocus)
+
+            % visibleRows : list of indices of rows to show
+            % requestFocus : boolean, whether table should request focus.
+
+            % Note: When updating filters (especially search autocomplete)
+            % the table should not request focus. In other cases, I dont
+            % remember why the table should request focus...
+
+            if isempty(obj.ColumnModel); return; end % On construction...
+
+            [numRows, numColumns] = size(obj.MetaTableCell); %#ok<ASGLU>
+
+            if nargin < 2 || isempty(visibleRows); visibleRows = 1:numRows; end
+            if nargin < 3 || isempty(requestFocus); requestFocus = true; end
+
+            % Get based on user selection of which columns to display
+            visibleColumns = obj.getCurrentColumnSelection();
+
+            % Get visible rows based on filter states
+            filteredRows = obj.getCurrentRowSelection();
+            visibleRows = intersect(filteredRows, visibleRows, 'stable');
+
+            % Get subset of data from metatable that should be put in the
+            % uitable.
+            tableDataView = obj.MetaTableCell(visibleRows, visibleColumns);
+
+            % Rearrange columns according to current state of the java
+            % column model
+            [javaColIndex, ~] = obj.ColumnModel.getColumnModelIndexOrder();
+            javaColIndex = javaColIndex(1:numel(visibleColumns));
+            tableDataView(:, javaColIndex) = tableDataView;
+
+            % Assign updated table data to the uitable property
+            obj.HTable.Data = tableDataView;
+            obj.HTable.Visible = 'on';
+
+            obj.updateColumnLabelFilterIndicator()
+
+            % Why????
+            if requestFocus
+                obj.HTable.JTable.requestFocus()
+            end
+
+            drawnow
+        end
+
+        function updateColumnLayout(obj) %protected
+        %updateColumnLayout Update the columnlayout based on user settings
+
+            if isempty(obj.ColumnModel); return; end
+            if isempty(obj.MetaTable)
+                obj.HTable.ColumnName = {''};
+                drawnow
+                return;
+            end
+
+            colIndices = obj.ColumnModel.getColumnIndices();
+
+            % Set column names
+            [columnLabels, variableNames] = obj.ColumnModel.getColumnNames();
+            obj.HTable.ColumnName = columnLabels;
+
+            obj.updateColumnEditable()
+
+            % Set column widths
+            newColumnWidths = obj.ColumnModel.getColumnWidths();
+            obj.changeColumnWidths(newColumnWidths)
+
+            C = obj.MetaTableCell; % Column format is determined from the cell version of table.
+            C = C(:, colIndices);
+            T = obj.MetaTable(1,:); % Need to check original data for special data types, i.e enums
+            T = T(:, colIndices);
+
+            % Return if table has no rows.
+            if size(C,1)==0; return; end
+
+            % Set column format and formatdata
+            dataTypes = cellfun(@(cell) class(cell), C(1,:), 'uni', 0);
+            colFormatData = arrayfun(@(i) [], 1:numel(dataTypes), 'uni', 0);
+
+            dataTypes(strcmp(dataTypes, 'string')) = {'char'};
+            dataTypes(strcmp(dataTypes, 'categorical')) = {'char'};
+
+            % Note, this is done before checking for enum on purpose
+            % (Todo: Adapt special enum classes to also use the CompactDisplayProvider...)
+            isCustomDisplay = @(x) isa(x, 'matlab.mixin.CustomCompactDisplayProvider');
+            isCustomDisplayObj = cellfun(@(cell) isCustomDisplay(cell), table2cell(T(1,:)), 'uni', 1);
+            dataTypes(isCustomDisplayObj) = {'char'};
+
+% % %             % Note: Important to reset this before updating. Columns can be
+% % %             % rearranged and number of columns can change. If
+% % %             % ColumnFormatData does not match the specified column format
+% % %             % an error might occur.
+% % %             obj.HTable.ColumnFormatData = colFormatData;
+
+            % Enums: (here we need to use non-cell version). Todo: Find
+            % better solution...
+            isEnumeration = cellfun(@(cell) isenum(cell), table2cell(T(1,:)), 'uni', 1);
+            dataTypes(isEnumeration) = {'popup'};
+            enumerationIdx = find(isEnumeration);
+            for i = enumerationIdx
+                enumObject = T{1,i};
+                if iscell(enumObject); enumObject = enumObject{1}; end
+                [~, m] = enumeration( enumObject ); % need to get enum for original....
+                %colFormatData{i} = [C(1,i); m];
+                colFormatData{i} = m;
+            end
+
+            isCategorical = cellfun(@(cell) iscategorical(cell), table2cell(T(1,:)), 'uni', 1);
+            dataTypes(isCategorical) = {'popup'};
+            categoricalIdx = find(isCategorical);
+            for i = categoricalIdx
+                categoricalObject = T{1,i};
+                if iscell(categoricalObject); categoricalObject = categoricalObject{1}; end
+                if isprotected(categoricalObject)
+                    colFormatData{i} = categories(categoricalObject);
+                else
+                    % colFormatData{i} = categories(categoricalObject);
+
+                    % Add <undefined> as an option for unprotected categoricals
+                    % - Question: Does that responsibility lie here or upstream?
+                    colFormatData{i} = cat(1, '<undefined>', categories(categoricalObject));
+                end
+            end
+
+            % All numeric types should be called 'numeric'
+            isNumeric = cellfun(@(cell) isnumeric(cell), C(1,:), 'uni', 1);
+            dataTypes(isNumeric) = {'numeric'};
+
+            isDatetime = cellfun(@(cell) isdatetime(cell), C(1,:), 'uni', 1);
+            dataTypes(isDatetime) = {'date'};
+
+            % Todo: get from nansen preferences...
+            colFormatData(isDatetime) = {'MMM-dd-yyyy    '};
+
+            % NOTE: This is temporary. Need to generalize, not make special
+            % treatment for session table
+
+            isVarWithOptions = [obj.MetaTableVariableAttributes.HasOptions];
+            isValidType = strcmp([obj.MetaTableVariableAttributes.TableType], obj.MetaTableType);
+
+            customVarNames = {obj.MetaTableVariableAttributes(isVarWithOptions & isValidType).Name};
+            [customVarNames, iA] = intersect(variableNames, customVarNames);
+
+            for i = 1:numel(customVarNames)
+                thisName = customVarNames{i};
+                tableVarIndex = strcmp({obj.MetaTableVariableAttributes.Name}, thisName);
+
+                popupOptions = obj.MetaTableVariableAttributes(tableVarIndex).OptionsList;
+
+                dataTypes(iA(i)) = {'popup'};
+                if isa(popupOptions, 'cell') && numel(popupOptions) == 1
+                    colFormatData(iA(i)) = popupOptions;
+                else
+                    colFormatData(iA(i)) = {popupOptions};
+                end
+                obj.HTable.ColumnEditable(iA(i)) = true;
+            end
+
+            if any(strcmp(dataTypes, 'cell'))
+                error('The table contains values that can not be rendered. Please contact support.')
+            end
+
+            % Update the column formatting properties
+            obj.HTable.ColumnFormatData = []; % Reset ColumnFormatData before changing ColumnFormat
+            obj.HTable.ColumnFormat = dataTypes;
+            obj.HTable.ColumnFormatData = colFormatData;
+
+            % Set column names. Do this last because this will control that
+            % the correct number of columns are shown.
+            obj.HTable.ColumnName = columnLabels;
+
+            % Update indicators for table filters because these are reset
+            % when column name is set
+            obj.updateColumnLabelFilterIndicator()
+
+            obj.ColumnModel.updateJavaColumnModel()
+
+            % Maybe call this separately???
+            %obj.updateTableView()
+
+            % Need to update theme...? I should really comment nonsensical
+            % stuff better.
+            obj.HTable.Theme = obj.HTable.Theme;
+        end
+
+        function updateColumnLabelFilterIndicator(obj, filterActive)
+
+            if nargin < 2
+                filterActive = obj.ColumnFilter.isColumnFilterActive;
+            end
+
+            onColor = '#017100';
+
+            colIndices = obj.ColumnModel.getColumnIndices();
+            filterActive = filterActive(colIndices);
+
+            columnNames = obj.ColumnModel.getColumnNames();
+
+            for i = 1:numel(obj.HTable.ColumnName)
+                if ~isempty(filterActive) && filterActive(i)
+                    columnNames{i} = sprintf('<HTML><FONT color="%s">%s</Font>', onColor, columnNames{i});
+                    %columnNames{i} = sprintf('<HTML><FONT
+                    %color="%s"><b>%s</Font>', onColor, columnNames{i});
+                    %makes very bold
+                end
+            end
+            if ~isempty(columnNames)
+                obj.changeColumnNames(columnNames)
+            end
+        end
+
+        function updateColumnEditable(obj)
+        %updateColumnEditable Update the ColumnEditable property of table
+        %
+        %   Set column editable, adjusting for which columns are currently
+        %   displayed and whether table should be editable or not.
+
+            if isempty(obj.ColumnModel); return; end % On construction...
+
+            % Set column editable (By default, none are editable)
+            allowEdit = obj.ColumnModel.getColumnIsEditable;
+
+            [~, variableNames] = obj.ColumnModel.getColumnNames();
+            attributeColumnNames = {obj.MetaTableVariableAttributes.Name};
+            [~, ~, iC] = intersect(variableNames, attributeColumnNames, 'stable');
+
+            isEditable = [obj.MetaTableVariableAttributes(iC).IsEditable];
+            allowEdit = allowEdit & isEditable;
+
+            % Set ignoreFlag to editable if options allow
+            columnNames = obj.ColumnModel.getColumnNames();
+            if obj.AllowTableEdits
+                allowEdit( contains(lower(columnNames), 'ignore') ) = true;
+                allowEdit( contains(lower(columnNames), 'description') ) = true;
+            else
+                allowEdit(:) = false;
+            end
+
+            obj.HTable.ColumnEditable = allowEdit;
+
+        end
+
+        function changeColumnNames(obj, newNames)
+            obj.HTable.ColumnName = newNames;
+        end % Todo: make dependent property and set method (?)
+
+        function changeColumnWidths(obj, newWidths)
+
+            if isa(obj.HTable, 'uim.widget.StylableTable')
+                % Use custom method of table model to set column width.
+                obj.HTable.changeColumnWidths(newWidths)
+            else
+                obj.HTable.ColumnWidth = newWidths;
+            end
+
+        end % Todo: make dependent property and set method (?)
+
+        function changeColumnToShow(obj)
+
+        end % Todo: make dependent property and set method (?)
+
+        function changeColumnOrder(obj)
+            % todo howdo
+        end
+    end
+
+    methods (Access = private) % Update table & internal housekeeping
+
+        function onMetaTableSet(obj, newTable)
+        %onMetaTableSet Internal callback for when the MetaTable property
+        %is set.
+        %
+        % Need to store the metatable as a cell array for presenting it in
+        % the UI table. (Relevant mostly for MetaTable objects because they
+        % might contain column data that needs to be formatted.
+
+        % Todo: count number of columns of old and new;
+        % compare column names. If changed, reset/update column model...
+
+            if isa(newTable, 'nansen.metadata.MetaTable')
+                T = newTable.getFormattedTableData();
+                obj.MetaTableType = lower( newTable.getTableType() );
+                obj.MetaTableCell = table2cell(T);
+            elseif isa(newTable, 'table')
+                obj.MetaTableCell = table2cell(newTable);
+            end
+
+            % Update metatable variable attributes.
+            S = obj.getMetaTableVariableAttributes();
+            obj.MetaTableVariableAttributes = S;
+        end
+
+        function onMetaTableTypeSet(obj, oldType, newType)
+            obj.RequireReset = ~strcmp(oldType, newType);
+        end
+
+        function onTableVariableAttributesFcnSet(obj)
+            S = obj.getMetaTableVariableAttributes();
+            obj.MetaTableVariableAttributes = S;
+            if obj.IsConstructed
+                obj.updateColumnLayout()
+            end
+        end
+
+        function onTableFontSizeSet(obj)
+            if ~isempty(obj.HTable)
+                obj.HTable.FontSize = obj.TableFontSize;
+                obj.HTable.RowHeight = obj.TableFontSize + 20;
+            end
+        end
+
+        function onColumnFilterSet(obj)
+        %onColumnFilterSet Callback for property value set.
+            if ~isempty(obj.FilterChangedListener)
+                delete(obj.FilterChangedListener)
+            end
+
+            obj.FilterChangedListener = addlistener(obj.ColumnFilter, ...
+                'FilterUpdated', @obj.onFilterUpdated);
+        end
+
+        function onFilterUpdated(obj, src, evt)
+        %onFilterUpdated Callback for table filter update events
+
+            obj.updateTableView([], false)
+
+            if ~isempty(obj.ExternalFilterMap)
+                visibleRows = find( obj.ExternalFilterMap );
+            else
+                visibleRows = 1:size(obj.MetaTableCell, 1);
+            end
+
+            rows = obj.getCurrentRowSelection();
+            rows = intersect(rows, visibleRows, 'stable');
+
+            evtdata = uiw.event.EventData('RowIndices', rows, 'Type', 'TableFilterUpdate');
+            obj.notify('TableUpdated', evtdata)
+        end
+
+        function rowInd = getCurrentRowSelection(obj)
+            % Get row indices that are visible in the uitable
+
+            % Initialize the data filter map if it is empty.
+            [numRows, numColumns] = size(obj.MetaTableCell);
+            if isempty(obj.DataFilterMap)
+                obj.DataFilterMap = true(numRows, numColumns);
+            end
+
+            % Remove ignored entries based on preference in settings.
+            if ~obj.ShowIgnoredEntries
+
+                varNames = obj.MetaTable.Properties.VariableNames;
+
+                isIgnoreColumn = contains(lower(varNames), 'ignore');
+                if any(isIgnoreColumn)
+
+                    isIgnored = [ obj.MetaTableCell{:, isIgnoreColumn} ];
+
+                    % Negate values of the ignore flag in the filter map
+                    obj.DataFilterMap(:, isIgnoreColumn) = ~isIgnored;
+                end
+            end
+
+            % Get indices for rows where all cells in the map are true
+            rowInd = find( all(obj.DataFilterMap, 2) );
+
+            if ~isempty(obj.ExternalFilterMap)
+                rowInd = intersect(rowInd, find(obj.ExternalFilterMap), 'stable');
+            end
+        end
+
+        function colInd = getCurrentColumnSelection(obj)
+            % Get column indices that are visible in the uitable
+            if isempty(obj.ColumnModel); return; end % On construction...
+
+            colInd = obj.ColumnModel.getColumnIndices();
+        end
+
+        function updateMetaTableVariableAttributes(obj)
+            obj.MetaTableVariableAttributes = ...
+                obj.getMetaTableVariableAttributes();
+        end
+
+        function S = getMetaTableVariableAttributes(obj)
+        % Get metatable variable attributes based on table type.
+
+            if ~isempty(obj.GetTableVariableAttributesFcn)
+                S = obj.GetTableVariableAttributesFcn(obj.MetaTableType);
+            else
+                S = obj.getDefaultMetaTableVariableAttributes();
+            end
+        end
+
+        function S = getDefaultMetaTableVariableAttributes(obj)
+        %Get default table variable attributes from TableVariable class.
+            import nansen.metadata.abstract.TableVariable;
+
+            varNames = obj.MetaTable.Properties.VariableNames;
+            numVars = numel(varNames);
+            S = TableVariable.getDefaultTableVariableAttribute();
+            S = repmat(S, 1, numVars);
+
+            % Fill out names and table type
+            [S(1:numVars).Name] = varNames{:};
+            [S(1:numVars).TableType] = deal(obj.MetaTableType);
+        end
+    end
+
+    methods (Access = private) % Mouse / user event callbacks
+
+        function onHeaderPressTimerRunOut(obj, src, evt)
+
+            if isempty(obj.ColumnPressedTimer)
+                return
+            end
+
+            stop(obj.ColumnPressedTimer)
+            delete(obj.ColumnPressedTimer)
+            obj.ColumnPressedTimer = [];
+
+            clickPosX = get(evt, 'X');
+            clickPosY = get(evt, 'Y');
+            obj.openColumnFilter(clickPosX, clickPosY)
+
+        end
+
+        function onMousePressedInHeader(obj, src, evt)
+        %onMousePressedInHeader Handles mouse press in the table header.
+
+            buttonNum = get(evt, 'Button');
+            if get(evt,'Modifiers')==18,
+                buttonNum = 3;
+            end;
+            obj.lastMousePressTic = tic;
+
+            % Need to call this to make sure filterdropdowns disappear if
+            % mouse is pressed in column header...
+            obj.ColumnFilter.hideFilters();
+
+            % Check the cursor type of the mouse pointer. If it equals 11,
+            % it corresponds with the special case when the pointer is
+            % clicked on the border between to columns. In this case, abort.
+            if obj.HTable.JTable.getTableHeader().getCursor().getType() == 11
+                return
+            end
+
+            % The action of pressing and holding for a split second should
+            % open the column filter. This is managed by a timer, and here,
+            % if a timer is not already active we start it and set the
+            % sortable to false
+            if buttonNum == 1 && get(evt, 'ClickCount') == 1
+
+                if isempty(obj.ColumnPressedTimer)
+                    obj.ColumnPressedTimer = timer();
+                    obj.ColumnPressedTimer.Period = 1;
+                    obj.ColumnPressedTimer.StartDelay = 0.25;
+                    obj.ColumnPressedTimer.TimerFcn = @(s,e) obj.onHeaderPressTimerRunOut(s, evt);
+                    start(obj.ColumnPressedTimer)
+                    obj.HTable.JTable.getModel().setSortable(0)
+                end
+
+            % For right clicks, open the context menu.
+            elseif buttonNum == 3 %rightclick
+
+                % These are coords in table
+                clickPosX = get(evt, 'X');
+                clickPosY = get(evt, 'Y');
+
+                % todo: get column header x- and y positions in figure.
+                obj.openColumnContextMenu(clickPosX, clickPosY);
+            end
+        end
+
+        function onMouseDraggedInTableHeader(obj, src, evt)
+
+            if ~isempty( obj.ColumnPressedTimer )
+                % Simulate mouse release to cancel the timer
+                obj.onMouseReleasedFromHeader([], [])
+            end
+
+            dPos = (evt.MousePointCurrent -  evt.MousePointStart);
+            dS = sqrt(sum(dPos.^2));
+
+            if dS > 10
+                if ~isempty(obj.ColumnFilter)
+                    obj.ColumnFilter.hideFilters();
+                end
+            end
+        end
+
+        function onMouseReleasedFromHeader(obj, src, evt)
+
+            if ~isempty(obj.ColumnPressedTimer)
+                stop(obj.ColumnPressedTimer)
+                delete(obj.ColumnPressedTimer)
+                obj.ColumnPressedTimer = [];
+
+                % Mouse was released before 1 second passed.
+                obj.HTable.JTable.getModel().setSortable(1)
+            end
+        end
+
+        function onMousePressedInTable(obj, src, evt)
+        %onMousePressedInTable Callback for mousepress in table.
+        %
+        %   This function is primarily used for
+        %       1) Creating an action on doubleclick
+        %       2) Selecting cell on right click
+
+            % Return if instance is not valid.
+            if ~exist('obj', 'var') || ~isvalid(obj); return; end
+
+            obj.ColumnFilter.hideFilters()
+            if isempty(obj.MetaTable); return; end
+            obj.updateColumnEditable()
+
+            if strcmp(evt.SelectionType, 'normal')
+                % Do nothing.
+                % Get row where mouse press occurred.
+                row = evt.Cell(1); col = evt.Cell(2);
+                if row == 0 || col == 0
+                    obj.HTable.SelectedRows = [];
+
+                    % Make sure editable cell is not in focus when editing
+                    % is stopped, because it will be rendered with a black
+                    % background.
+                    colIdx = find( ~obj.HTable.ColumnEditable, 1, 'first');
+
+                    cellEditor = obj.HTable.JTable.getCellEditor();
+                    if ~isempty( cellEditor )
+                        cellEditor.stopCellEditing();
+                    end
+
+                    selectionModel = obj.HTable.JTable.getColumnModel.getSelectionModel;
+
+                    if ~isempty(colIdx)
+                        % Give focus to a non-editable cell.
+                        set(selectionModel, 'LeadSelectionIndex', colIdx-1)
+                    else
+                        % Set selection index to something near guaranteed
+                        % to not be in the current table (if no cells are
+                        % non-editable)
+                        set(selectionModel, 'LeadSelectionIndex', 9999)
+                    end
+                end
+
+            elseif strcmp(evt.SelectionType, 'open')
+
+                if ~isempty(obj.MouseDoubleClickedFcn)
+                    obj.MouseDoubleClickedFcn(src, evt)
+                else
+                    obj.onMouseDoubleClickedInTable(src, evt)
+                end
+
+                % Todo:
+                % Double click action should depend on which column click
+                % happens over.
+
+% %                     if isequal(get(event, 'button'), 3)
+% %                         return
+% %                     end
+% %
+% %                     currentFields = app.tableSettings.FieldNames(app.tableSettings.FieldsToShow);
+% %                     so = retrieveSessionObject(app, app.highlightedSessions(end));
+% %
+% %                     if numel(app.highlightedSessions) > 1
+% %                         warning('Multiple sessions, selected, operation applies to last session only.')
+% %                     end
+% %
+% %                     if strcmp(currentFields{j+1}, 'Notes')
+% %                         app.showNotes(so.sessionID)
+% %                     else
+% %                         %so.openFolder
+% %                         openFolder(so.sessionID, 'datadrive', 'processed')
+% %                     end
+
+            elseif evt.Button == 3 || strcmp(evt.SelectionType, 'alt')
+
+                if ismac && evt.Button == 1 && evt.MetaOn
+                    return % Command click on mac should not count as right click
+                end
+
+                if ispc && evt.Button == 1 && evt.ControlOn
+                    return % Control click on windows should not count as right click
+                end
+
+                % Get row where mouse press occurred.
+                row = evt.Cell(1); col = evt.Cell(2);
+
+                % Select row where mouse is pressed if it is not already
+                % selected
+                if ~ismember(row, obj.HTable.SelectedRows)
+                    if row > 0 && col > 0
+                        obj.HTable.SelectedRows = row;
+                    else
+                        obj.HTable.SelectedRows = [];
+                        return
+                    end
+                end
+
+                % Open context menu for table
+                if ~isempty(obj.TableContextMenu)
+                    position = obj.getTableContextMenuPosition(evt.Position);
+                    obj.openTableContextMenu(position(1), position(2));
+                end
+            end
+        end
+
+        function onMouseDoubleClickedInTable(obj, src, evt)
+        % onMouseDoubleClickedInTable - Callback for double clicks
+        %
+        %   Check if the currently selected column has an associated table
+        %   variable definition with a double click callback function.
+
+        % Note: currently not used
+
+            thisRow = evt.Cell(1); % Clicked row index
+            thisCol = evt.Cell(2); % Clicked column index
+
+            if thisRow == 0 || thisCol == 0
+                return
+            end
+
+            % Get name of column which was clicked
+            thisColumnName = obj.getColumnNames(thisCol);
+
+            % Use table variable attributes to check if a double click
+            % callback function exists for the current table column
+            TVA = obj.MetaTableVariableAttributes([obj.MetaTableVariableAttributes.HasDoubleClickFunction]);
+
+            isMatch = strcmp(thisColumnName, {TVA.Name});
+
+            if any( isMatch )
+                tableVariableClassName = TVA(isMatch).ClassName;
+
+                if ~isempty(tableVariableClassName)
+                    tableRowIdx = app.UiMetaTableViewer.getMetaTableRows(thisRow); % Visible row to data row transformation
+                    tableValue = app.MetaTable.entries{tableRowIdx, thisColumnName};
+                    tableVariableObj = feval(tableVariableClassName, tableValue);
+
+                    tableRowData = app.MetaTable.entries(tableRowIdx,:);
+                    metaObj = app.tableEntriesToMetaObjects( tableRowData );
+                    tableVariableObj.onCellDoubleClick( metaObj );
+                else
+                    if isa(TVA(isMatch).DoubleClickFunctionName, 'function_handle')
+                        TVA(isMatch).DoubleClickFunctionName()
+                    else
+                        error('Not supported')
+                    end
+                end
+            end
+        end
+
+
+        function onMouseMotionInTable(obj, src, evt)
+            % This functionality is put in the nansen app for now.
+        end
+
+        function onCellValueEdited(obj, src, evtData)
+        %onCellValueEdited Callback for value change in cell
+        %
+        %   1) Update original table data
+        %   2) Modify evtData and pass on to class' CellEditCallback
+
+        % Todo: For time being (oct2021) the only editable column is the
+        % ignore flag column. Should refresh the table if ignore rows are
+        % set to hidden, but for now, the ignored rows will disappear on
+        % next table update.
+
+            % Get currently visible row and column indices.
+            rowInd = obj.getCurrentRowSelection();
+            colInd = obj.getCurrentColumnSelection();
+
+            % Get row and column indices for original data (unfiltered, unsorted, allcolumns)
+            tableRowInd = rowInd(evtData.Indices(1));
+
+            evtColIdx = obj.ColumnModel.getColumnIdx( evtData.Indices(2) ); % 2 is for columns
+            tableColInd = colInd(evtColIdx);
+
+            % Todo: Implement this, if dropdown contains actionable options
+            % formatted like this: <action name>
+            % % newValue = evtData.NewValue;
+            % % if startsWith(newValue, '<') && endsWith(newValue, '>')
+            % %     evtData.NewValue = [];
+            % % end
+
+            % Update value in table and table cell array
+            %obj.MetaTable(tableRowInd, tableColInd) = {evtData.NewValue};
+            obj.MetaTableCell{tableRowInd, tableColInd} = evtData.NewValue;
+
+            % Invoke external callback if it is assigned.
+            if ~isempty( obj.CellEditCallback )
+                evtData.Indices = [tableRowInd, tableColInd];
+                obj.CellEditCallback(src, evtData)
+            end
+        end
+
+        function onCellSelectionChanged(obj, src, evt)
+            %evtData = event.EventData;
+            evtData = uiw.event.EventData('SelectedRows', evt.SelectedRows);
+            obj.notify('SelectionChanged', evtData)
+        end
+
+        function onColumnWidthChanged(obj, src, event)
+        %onColumnWidthChanged Callback for events where column widths are
+        %changed by resizing column widths in from gui.
+            obj.ColumnModel.setColumnWidths(obj.HTable.ColumnWidth)
+        end
+
+        function onColumnsRearranged(obj, src, evt)
+        %onColumnsRearranged Callback for event when columns are rearranged
+        %
+        % This event is triggered when user drags columns to rearrange
+
+            % Tell columnmodel of new order...
+            newColumnArrangement = obj.HTable.getColumnOrder;
+            obj.ColumnModel.setNewColumnOrder(newColumnArrangement)
+
+            if ~isempty(obj.ColumnFilter)
+                obj.ColumnFilter.hideFilters();
+            end
+        end
+
+        function columnIdx = getColumnAtPoint(obj, x, y)
+        %getColumnAtPoint Returns the column index at point (x,y)
+        %
+        %   Conversion from java to matlab:
+
+            mPos = java.awt.Point(x, y);
+            columnIdx = obj.HTable.JTable.columnAtPoint(mPos) + 1;
+            % Note, java indexing starts at 0, so added 1.
+
+        end
+
+        function position = getTableContextMenuPosition(obj, eventPosition)
+        %getTableContextMenuPosition Get cmenu position from event position
+
+            % Get scroll positions in table
+            xScroll = obj.HTable.getHorizontalScrollOffset();
+            yScroll = obj.HTable.getVerticalScrollOffset();
+
+            % Get position where mouseclick occurred (in figure)
+            clickPosX = eventPosition(1) - xScroll;
+            clickPosY = eventPosition(2) - yScroll;
+
+            % Convert to position inside table
+            tablePosition = getpixelposition(obj.HTable, true);
+            tableLocationX = tablePosition(1);
+            tableHeight = tablePosition(4);
+
+            positionX = clickPosX + tableLocationX + 1; % +1 because ad hoc...
+            % obj.HTable.RowHeight??
+            positionY = tableHeight - clickPosY + 19; % +15 because ad hoc... size of table header?
+            position = [positionX, positionY];
+
+        end
+
+        function figureCoords = javapoint2figurepoint(obj, javaCoords)
+        %javapoint2figurepoint Find coordinates of point in figure units
+        %
+        %   figureCoords = javapoint2figurepoint(obj, javaCoords) returns
+        %   figureCoords ([x,y]) of point in figure (measured from lower
+        %   left corner) based on javaCoords ([x,y]) from a java mouse
+        %   event in the table (measured from upper left corner in table).
+
+            % Note:
+            % x is position measured from left inside table
+            % y is position measured from top inside table
+
+            % Get pixel position of table referenced in figure.
+            tablePosition = getpixelposition(obj.HTable, true);
+
+            x0 = tablePosition(1);
+            y0 = tablePosition(2);
+            tableHeight = tablePosition(4);
+
+            xPosition = x0 + javaCoords(1);
+            yPosition = y0 + tableHeight - javaCoords(2);
+
+            figureCoords = [xPosition, yPosition];
+
+        end
+
+        function openColumnContextMenu(obj, x, y)
+
+            colNumber = obj.getColumnAtPoint(x, y);
+            if colNumber == 0; return; end
+
+            if isempty(obj.ColumnContextMenu)
+                obj.createColumnContextMenu()
+            end
+
+            % Get column name of column where context menu should open
+            [~, varNames] = obj.ColumnModel.getColumnNames();
+            currentColumnName = varNames{colNumber};
+
+            % Get column number according to the underlying java column
+            % models column order.
+            [colIdxJava, ~] = obj.ColumnModel.getColumnModelIndexOrder();
+            colNumber = colIdxJava(colNumber);
+
+            columnType = obj.HTable.ColumnFormat{colNumber};
+
+            isMatch = strcmp( {obj.MetaTableVariableAttributes.Name}, currentColumnName ) & ...
+                contains([obj.MetaTableVariableAttributes.TableType], obj.MetaTableType, 'IgnoreCase', true);
+            if any(isMatch)
+                varAttr = obj.MetaTableVariableAttributes(isMatch);
+            else
+                error('Variable attributes does not exist. This is unexpected.')
+            end
+
+            % Select appearance of context menu based on column type:
+            for i = 1:numel(obj.ColumnContextMenu.Children)
+                hTmp = obj.ColumnContextMenu.Children(i);
+
+                switch hTmp.Tag
+                    case 'Sort Ascend'
+                        switch columnType
+                            case 'char'
+                                hTmp.Label = 'Sort A-Z';
+                            case 'numeric'
+                                hTmp.Label = 'Sort low-high';
+                            case 'logical'
+                                hTmp.Label = 'Sort false-true';
+                        end
+                        hTmp.Callback = @(s,e,iCol,dir) obj.sortColumn(colNumber,'ascend');
+
+                    case 'Sort Descend'
+                        switch columnType
+                            case 'char'
+                                hTmp.Label = 'Sort Z-A';
+                            case 'numeric'
+                                hTmp.Label = 'Sort high-low';
+                            case 'logical'
+                                hTmp.Label = 'Sort true-false';
+                        end
+                        hTmp.Callback = @(s,e,iCol,dir) obj.sortColumn(colNumber,'descend');
+
+                    case 'Filter'
+                        hTmp.Callback = @(s,e,iCol) obj.filterColumn(colNumber);
+                    case 'Reset Filters'
+                        hTmp.Callback = @(s,e,iCol) obj.resetColumnFilters();
+
+                    case 'Hide Column'
+                        hTmp.Callback = @(s,e,iCol) obj.hideColumn(colNumber);
+
+                    case 'Update Column'
+                        if varAttr.HasUpdateFunction % (Does it have to be custom?)% varAttr.IsCustom && varAttr.HasUpdateFunction
+                            hTmp.Enable = 'on';
+                            if ~isempty(obj.UpdateColumnFcn)
+                                % Children are reversed from creation
+                                hTmp.Children(1).Callback = @(s,e,name) obj.EditColumnFcn(currentColumnName);
+                                hTmp.Children(2).Callback = @(name, mode) obj.ResetColumnFcn(currentColumnName, 'AllRows');
+                                hTmp.Children(3).Callback = @(name, mode) obj.ResetColumnFcn(currentColumnName, 'SelectedRows');
+                                hTmp.Children(4).Callback = @(name, mode) obj.UpdateColumnFcn(currentColumnName, 'AllRows');
+                                hTmp.Children(5).Callback = @(name, mode) obj.UpdateColumnFcn(currentColumnName, 'SelectedRows');
+                            end
+                        else
+                            hTmp.Enable = 'off';
+                        end
+
+                    case 'Delete Column'
+                        if varAttr.IsCustom
+                            hTmp.Enable = 'on';
+                            if ~isempty(obj.DeleteColumnFcn)
+                                hTmp.Callback = @(colName, evt) obj.DeleteColumnFcn(currentColumnName);
+                            end
+                        else
+                            hTmp.Enable = 'off';
+                        end
+
+                    otherwise
+                        % Do nothing
+                end
+            end
+
+            % Get the coordinates for where to show the context menu
+            figurePoint = obj.javapoint2figurepoint([x, y]);
+
+            % Adjust for the horizontal scroll position in the table.
+            xOff = obj.HTable.getHorizontalScrollOffset();
+            figurePoint = figurePoint - [xOff, 0];
+
+            % Set position and make menu visible.
+            obj.ColumnContextMenu.Position = figurePoint;
+            obj.ColumnContextMenu.Visible = 'on';
+
+        end
+
+        function openTableContextMenu(obj, x, y)
+
+            if isempty(obj.TableContextMenu); return; end
+
+            % Set position and make menu visible.
+            obj.TableContextMenu.Position = [x,y];
+            obj.TableContextMenu.Visible = 'on';
+
+        end
+
+        function openColumnFilter(obj, x, y)
+        %openColumnFilter Open column filter as dropdown below column header
+
+            tableColumnIdx = obj.getColumnAtPoint(x, y);
+            if tableColumnIdx == 0; return; end
+
+            colIndices = obj.ColumnModel.getColumnIndices();
+            dataColumnIndex = colIndices(tableColumnIdx);
+
+            obj.ColumnFilter.openFilterControl(dataColumnIndex)
+
+        end
+
+        function filterColumn(obj, columnNumber)
+        %filterColumn Open column filter in sidepanel
+
+            colIndices = obj.ColumnModel.getColumnIndices();
+            dataColumnIndex = colIndices(columnNumber);
+
+            obj.ColumnFilter.openFilterControl(dataColumnIndex)
+            obj.AppRef.showSidePanel()
+
+        end
+
+        function sortColumn(obj, columnIdx, sortDirection)
+        %sortColumn Sort column in specified direction
+            sortAscend = strcmp(sortDirection, 'ascend');
+            sortDescend = strcmp(sortDirection, 'descend');
+
+            obj.HTable.JTable.sortColumn(columnIdx-1, 1, sortAscend)
+
+        end
+
+        function hideColumn(obj, columnNumber)
+            obj.ColumnModel.hideColumn(columnNumber);
+        end
+    end
+
+    methods (Static)
+
+        function tf = isValidTableClass(var)
+        %isValidTable Test if var satisfies the list of valid table classes
+            VALID_CLASSES = nansen.ui.metatable.LegacyJavaMetaTableViewer.VALID_TABLE_CLASS;
+            tf = any(cellfun(@(type) isa(var, type), VALID_CLASSES));
+        end
+    end
+end

--- a/code/+nansen/+ui/+metatable/ModernMetaTableColumnFilter.m
+++ b/code/+nansen/+ui/+metatable/ModernMetaTableColumnFilter.m
@@ -1,0 +1,108 @@
+classdef ModernMetaTableColumnFilter < handle
+%ModernMetaTableColumnFilter Filtering state for the native table backend.
+%
+%   The legacy filter class owns Java/uicontrol popup widgets. This modern
+%   class keeps the filtering contract in place without depending on Java.
+%   A richer uifigure filter UI can be layered onto this class later.
+
+    properties
+        AppReference
+        ComponentPanel
+        hColumnFilterPopups
+        columnFilterType
+        isColumnFilterActive
+        isColumnFilterDirty
+    end
+
+    properties (SetAccess = private)
+        MetaTableUi
+        TableParent
+    end
+
+    properties (Dependent, SetAccess = private)
+        MetaTable
+    end
+
+    events
+        FilterUpdated
+    end
+
+    methods
+        function obj = ModernMetaTableColumnFilter(uiTable, appRef)
+            obj.MetaTableUi = uiTable;
+            obj.AppReference = appRef;
+
+            if isa(obj.MetaTableUi.MetaTable, 'table')
+                obj.onMetaTableChanged()
+            end
+        end
+
+        function metaTable = get.MetaTable(obj)
+            metaTable = obj.MetaTableUi.MetaTableCell;
+        end
+    end
+
+    methods
+        function onMetaTableChanged(obj)
+            obj.reinitializeFilterControlProperties()
+        end
+
+        function onMetaTableUpdated(obj)
+            if isempty(obj.hColumnFilterPopups)
+                obj.onMetaTableChanged()
+            end
+        end
+
+        function popup = openFilterControl(obj, columnIdx)
+            popup = [];
+            if isempty(obj.MetaTableUi) || ~isvalid(obj.MetaTableUi)
+                return
+            end
+
+            popup = obj.MetaTableUi.openFilterControl(columnIdx);
+            if isempty(popup)
+                return
+            end
+
+            if isempty(obj.hColumnFilterPopups)
+                obj.reinitializeFilterControlProperties()
+            end
+            obj.hColumnFilterPopups{columnIdx} = popup;
+        end
+
+        function deleteFilterControls(obj)
+            obj.hColumnFilterPopups = {};
+        end
+
+        function reinitializeFilterControlProperties(obj)
+            if isempty(obj.MetaTableUi.MetaTable)
+                numColumns = 0;
+            else
+                numColumns = width(obj.MetaTableUi.MetaTable);
+            end
+
+            obj.hColumnFilterPopups = cell(numColumns, 1);
+            obj.columnFilterType = repmat({'N/A'}, numColumns, 1);
+            obj.isColumnFilterActive = false(numColumns, 1);
+            obj.isColumnFilterDirty = false(numColumns, 1);
+        end
+
+        function resetFilters(obj)
+            obj.MetaTableUi.clearUserColumnFilters()
+        end
+
+        function hideFilters(~)
+        end
+
+        function setActiveVariableNames(obj, variableNames)
+            obj.isColumnFilterActive(:) = false;
+            if isempty(variableNames) || isempty(obj.MetaTableUi.MetaTable)
+                return
+            end
+
+            tableVariableNames = string(obj.MetaTableUi.MetaTable.Properties.VariableNames);
+            obj.isColumnFilterActive = ismember(tableVariableNames, string(variableNames(:)));
+            obj.isColumnFilterDirty(:) = true;
+        end
+    end
+end

--- a/code/+nansen/+ui/+metatable/ModernUiMetaTableViewer.m
+++ b/code/+nansen/+ui/+metatable/ModernUiMetaTableViewer.m
@@ -1,0 +1,986 @@
+classdef ModernUiMetaTableViewer < handle
+%ModernUiMetaTableViewer Native MATLAB table backend for metadata tables.
+
+    properties (Constant, Hidden)
+        VALID_TABLE_CLASS = {'nansen.metadata.MetaTable', 'table'};
+    end
+
+    properties
+        ShowIgnoredEntries = true
+        AllowTableEdits = true
+        TableFontSize = 12
+        MetaTableType = 'session'
+
+        SelectedEntries
+        CellEditCallback
+        KeyPressCallback
+        MouseDoubleClickedFcn = []
+
+        DeleteColumnFcn = []
+        UpdateColumnFcn = []
+        ResetColumnFcn = []
+        EditColumnFcn = []
+        GetTableVariableAttributesFcn = []
+    end
+
+    properties (SetAccess = private, SetObservable = true)
+        MetaTable
+        MetaTableCell cell
+        MetaTableVariableNames
+        MetaTableVariableAttributes
+    end
+
+    properties (Dependent)
+        ColumnSettings
+        DisplayedRows
+    end
+
+    properties (SetAccess = private)
+        ColumnModel
+        ColumnFilter
+    end
+
+    properties
+        AppRef
+        Parent
+        HTable
+        JTable = []
+
+        ColumnContextMenu = []
+        TableContextMenu = []
+
+        DataFilterMap = []
+        ExternalFilterMap = []
+        FilterChangedListener event.listener
+    end
+
+    properties (Access = private)
+        ColumnSettings_
+        DisplayRowIndex = []
+        DisplayColumnIndex = []
+        IsConstructed = false
+        RequireReset = false
+        MouseMotionCallback = []
+        HtmlStyleConfigurationRows = []
+    end
+
+    events
+        TableUpdated
+        SelectionChanged
+    end
+
+    methods
+        function obj = ModernUiMetaTableViewer(varargin)
+            obj.parseInputs(varargin)
+
+            obj.ColumnModel = nansen.ui.MetaTableColumnLayout(...
+                obj, 'ColumnSettings', obj.ColumnSettings);
+            obj.createUiTable()
+            obj.ColumnFilter = nansen.ui.metatable.ModernMetaTableColumnFilter(obj, obj.AppRef);
+
+            obj.IsConstructed = true;
+
+            if ~isempty(obj.MetaTableCell)
+                obj.refreshTable()
+                obj.HTable.Visible = 'on';
+                drawnow
+            end
+        end
+
+        function delete(obj)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable)
+                columnWidths = obj.normalizeColumnWidths(obj.HTable.ColumnWidth);
+                if ~isempty(columnWidths)
+                    obj.ColumnModel.setColumnWidths(columnWidths);
+                end
+                delete(obj.HTable)
+            end
+            if ~isempty(obj.ColumnModel) && isvalid(obj.ColumnModel)
+                delete(obj.ColumnModel)
+            end
+        end
+    end
+
+    methods
+        function rowIndices = get.DisplayedRows(obj)
+            if isempty(obj.MetaTableCell)
+                rowIndices = [];
+                return
+            end
+
+            if ~isempty(obj.ExternalFilterMap)
+                visibleRows = find(obj.ExternalFilterMap);
+            else
+                visibleRows = 1:size(obj.MetaTableCell, 1);
+            end
+
+            rowIndices = obj.getCurrentRowSelection();
+            rowIndices = intersect(rowIndices, visibleRows, 'stable');
+        end
+
+        function set.MetaTable(obj, newTable)
+            if isa(newTable, 'nansen.metadata.MetaTable')
+                obj.MetaTable = newTable.entries;
+            elseif isa(newTable, 'table')
+                obj.MetaTable = newTable;
+            else
+                error('New value of MetaTable property must be a MetaTable or a table object')
+            end
+
+            obj.onMetaTableSet(newTable)
+        end
+
+        function set.MetaTableType(obj, newValue)
+            oldType = obj.MetaTableType;
+            obj.MetaTableType = lower(newValue);
+            obj.RequireReset = ~strcmp(oldType, lower(newValue));
+        end
+
+        function set.ColumnSettings(obj, newSettings)
+            if isempty(obj.ColumnModel)
+                obj.ColumnSettings_ = newSettings;
+            else
+                obj.ColumnModel.replaceColumnSettings(newSettings);
+                obj.updateColumnLayout()
+            end
+        end
+
+        function colSettings = get.ColumnSettings(obj)
+            if isempty(obj.ColumnModel)
+                colSettings = obj.ColumnSettings_;
+            else
+                colSettings = obj.ColumnModel.settings;
+            end
+        end
+
+        function set.ColumnFilter(obj, newValue)
+            obj.ColumnFilter = newValue;
+            if ~isempty(newValue)
+                obj.onColumnFilterSet()
+            end
+        end
+
+        function set.ShowIgnoredEntries(obj, newValue)
+            assert(islogical(newValue), 'Value for ShowIgnoredEntries must be a boolean')
+            obj.ShowIgnoredEntries = newValue;
+            obj.refreshTable()
+        end
+
+        function set.AllowTableEdits(obj, newValue)
+            assert(islogical(newValue), 'Value for AllowTableEdits must be a boolean')
+            obj.AllowTableEdits = newValue;
+            obj.updateColumnEditable()
+        end
+
+        function set.TableFontSize(obj, newValue)
+            obj.TableFontSize = newValue;
+            obj.onTableFontSizeSet()
+        end
+
+        function set.KeyPressCallback(obj, newValue)
+            obj.KeyPressCallback = newValue;
+            obj.setKeyPressFcn(newValue)
+        end
+
+        function set.GetTableVariableAttributesFcn(obj, newValue)
+            obj.GetTableVariableAttributesFcn = newValue;
+            obj.onTableVariableAttributesFcnSet()
+        end
+    end
+
+    methods
+        function refreshColumnModel(obj, varargin)
+            obj.ColumnModel.updateColumnEditableState()
+        end
+
+        function resetTable(obj, resetView)
+            if nargin < 2
+                resetView = true;
+            end
+
+            obj.MetaTable = table.empty;
+
+            if resetView
+                obj.refreshTable(table.empty, true)
+            end
+        end
+
+        function resetColumnFilters(obj)
+            obj.ColumnFilter.resetFilters()
+        end
+
+        function updateCells(obj, rowIdxData, colIdxData, newData)
+            obj.MetaTableCell(rowIdxData, colIdxData) = newData;
+            obj.updateTableView([], false)
+            drawnow
+        end
+
+        function updateTableRow(obj, rowIdxData, tableRowData)
+            colIdx = 1:size(tableRowData, 2);
+            if isa(tableRowData, 'table')
+                tableRowData = table2cell(tableRowData);
+            end
+            obj.updateCells(rowIdxData, colIdx, tableRowData)
+        end
+
+        function updateFormattedTableColumnData(obj, columnName, columnData)
+            columnIndex = find(strcmp(obj.MetaTable.Properties.VariableNames, columnName));
+            obj.MetaTableCell(:, columnIndex) = table2cell(columnData);
+        end
+
+        function appendTableRow(~, ~)
+        end
+
+        function updateVisibleRows(obj, rowInd)
+            [numRows, ~] = size(obj.MetaTable);
+            obj.ExternalFilterMap = false(numRows, 1);
+            obj.ExternalFilterMap(rowInd) = true;
+            obj.updateTableView(rowInd)
+        end
+
+        function refreshTable(obj, newTable, flushTable)
+            requireReset = isempty(obj.MetaTable) || obj.RequireReset;
+
+            if nargin >= 2 && ~(isnumeric(newTable) && isempty(newTable))
+                obj.MetaTable = newTable;
+            end
+
+            if nargin < 3 || isempty(flushTable)
+                flushTable = requireReset;
+            end
+
+            if flushTable
+                obj.HTable.Data = {};
+                obj.DataFilterMap = [];
+                if ~isempty(obj.MetaTable)
+                    obj.ColumnFilter.onMetaTableChanged()
+                end
+                obj.RequireReset = false;
+            elseif ~isempty(obj.ColumnFilter)
+                obj.ColumnFilter.onMetaTableUpdated()
+            end
+
+            drawnow
+            if ~isempty(obj.MetaTable)
+                obj.updateMetaTableVariableAttributes()
+                obj.updateColumnLayout()
+                obj.updateTableView()
+            else
+                obj.HTable.ColumnName = cell(1,0);
+            end
+        end
+
+        function replaceTable(obj, newTable)
+            obj.MetaTable = newTable;
+            obj.ColumnFilter.onMetaTableChanged()
+            obj.updateTableView()
+        end
+
+        function rowInd = getMetaTableRows(obj, rowIndDisplay)
+            if isempty(rowIndDisplay)
+                rowInd = [];
+                return
+            end
+
+            rowIndDisplay = rowIndDisplay(rowIndDisplay > 0);
+            rowInd = obj.DisplayRowIndex(rowIndDisplay);
+
+            if iscolumn(rowInd)
+                rowInd = transpose(rowInd);
+            end
+        end
+
+        function IND = getSelectedEntries(obj)
+            if isempty(obj.HTable) || isempty(obj.HTable.Selection)
+                IND = [];
+                return
+            end
+
+            selectedRows = obj.getSelectedViewRows();
+            selectedRows = selectedRows(selectedRows > 0 & selectedRows <= numel(obj.DisplayRowIndex));
+            IND = obj.DisplayRowIndex(selectedRows);
+            IND = transpose(double(sort(unique(IND))));
+        end
+
+        function setSelectedEntries(obj, IND, preventCallback)
+            if nargin < 3
+                preventCallback = false; %#ok<NASGU>
+            end
+
+            if isempty(IND)
+                obj.HTable.Selection = [];
+                return
+            end
+
+            [isVisible, selectedRows] = ismember(IND, obj.DisplayRowIndex);
+            selectedRows = selectedRows(isVisible);
+
+            if isempty(selectedRows)
+                obj.HTable.Selection = [];
+            else
+                obj.HTable.Selection = reshape(selectedRows, 1, []);
+            end
+        end
+
+        function [columnNames, variableNames] = getColumnNames(obj, columnIndices)
+            if nargin < 2
+                columnIndices = [];
+            end
+
+            [columnNames, variableNames] = obj.ColumnModel.getColumnNames();
+            if ~isempty(columnIndices)
+                columnNames = columnNames(columnIndices);
+                variableNames = variableNames(columnIndices);
+            end
+            if numel(columnNames) == 1 && iscell(columnNames)
+                columnNames = columnNames{1};
+                variableNames = variableNames{1};
+            end
+        end
+
+        function focusTable(obj)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable)
+                try
+                    uifocus(obj.HTable)
+                catch
+                    hFigure = ancestor(obj.HTable, 'figure');
+                    if ~isempty(hFigure) && isvalid(hFigure)
+                        figure(hFigure)
+                    end
+                end
+            end
+        end
+
+        function setTableTooltip(obj, tooltipText)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable)
+                obj.HTable.Tooltip = tooltipText;
+            end
+        end
+
+        function setKeyPressFcn(obj, callback)
+            if ~isempty(obj.HTable) && isvalid(obj.HTable)
+                obj.HTable.KeyPressFcn = callback;
+            end
+        end
+
+        function listenerHandle = addMouseMotionCallback(obj, callback)
+            obj.MouseMotionCallback = callback;
+            listenerHandle = [];
+        end
+
+        function n = getDisplayedRowCount(obj)
+            if isempty(obj.HTable) || isempty(obj.HTable.Data)
+                n = 0;
+            else
+                n = size(obj.HTable.Data, 1);
+            end
+        end
+
+        function n = getSelectedRowCount(obj)
+            n = numel(obj.getSelectedEntries());
+        end
+    end
+
+    methods (Access = {?nansen.ui.metatable.ModernUiMetaTableViewer, ?nansen.ui.MetaTableColumnLayout, ?nansen.ui.metatable.ModernMetaTableColumnFilter})
+        function updateTableView(obj, visibleRows, requestFocus)
+            if isempty(obj.ColumnModel) || isempty(obj.MetaTableCell)
+                return
+            end
+
+            if nargin < 2 || isempty(visibleRows)
+                visibleRows = 1:size(obj.MetaTableCell, 1);
+            end
+            if nargin < 3 || isempty(requestFocus)
+                requestFocus = true;
+            end
+
+            visibleColumns = obj.getCurrentColumnSelection();
+            filteredRows = obj.getCurrentRowSelection();
+            visibleRows = intersect(filteredRows, visibleRows, 'stable');
+
+            obj.DisplayRowIndex = visibleRows;
+            obj.DisplayColumnIndex = visibleColumns;
+
+            obj.HTable.Data = obj.getDisplayTableData(visibleRows, visibleColumns);
+            obj.HTable.Visible = 'on';
+
+            obj.updateColumnLabelFilterIndicator()
+
+            if requestFocus
+                obj.focusTable()
+            end
+
+            drawnow
+        end
+
+        function updateColumnLayout(obj)
+            if isempty(obj.ColumnModel)
+                return
+            end
+            if isempty(obj.MetaTable)
+                obj.HTable.ColumnName = {''};
+                drawnow
+                return
+            end
+
+            colIndices = obj.ColumnModel.getColumnIndices();
+            [columnLabels, variableNames] = obj.ColumnModel.getColumnNames();
+
+            obj.HTable.ColumnName = columnLabels;
+            obj.updateColumnEditable()
+            obj.changeColumnWidths(obj.ColumnModel.getColumnWidths())
+
+            C = obj.MetaTableCell(:, colIndices);
+            if size(C, 1) == 0
+                return
+            end
+
+            T = obj.MetaTable(1, colIndices);
+            columnFormat = repmat({'char'}, 1, numel(colIndices));
+
+            displayData = obj.getDisplayTableData(1, colIndices);
+            dataTypes = cellfun(@(cellValue) class(cellValue), displayData(1,:), 'UniformOutput', false);
+            dataTypes(strcmp(dataTypes, 'string')) = {'char'};
+            dataTypes(strcmp(dataTypes, 'categorical')) = {'char'};
+            dataTypes(strcmp(dataTypes, 'datetime')) = {'char'};
+            dataTypes(strcmp(dataTypes, 'duration')) = {'char'};
+
+            isCustomDisplay = @(x) isa(x, 'matlab.mixin.CustomCompactDisplayProvider');
+            isCustomDisplayObj = cellfun(@(cellValue) isCustomDisplay(cellValue), table2cell(T), 'UniformOutput', true);
+            dataTypes(isCustomDisplayObj) = {'char'};
+
+            isNumeric = cellfun(@(cellValue) isnumeric(cellValue), C(1,:), 'UniformOutput', true);
+            columnFormat(isNumeric) = {'numeric'};
+
+            isLogical = cellfun(@(cellValue) islogical(cellValue), C(1,:), 'UniformOutput', true);
+            columnFormat(isLogical) = {'logical'};
+
+            isEnumeration = cellfun(@(cellValue) isenum(cellValue), table2cell(T), 'UniformOutput', true);
+            for i = find(isEnumeration)
+                enumObject = T{1,i};
+                if iscell(enumObject)
+                    enumObject = enumObject{1};
+                end
+                [~, enumNames] = enumeration(enumObject);
+                columnFormat{i} = enumNames;
+            end
+
+            isCategorical = cellfun(@(cellValue) iscategorical(cellValue), table2cell(T), 'UniformOutput', true);
+            for i = find(isCategorical)
+                categoricalObject = T{1,i};
+                if iscell(categoricalObject)
+                    categoricalObject = categoricalObject{1};
+                end
+                if isprotected(categoricalObject)
+                    columnFormat{i} = categories(categoricalObject);
+                else
+                    columnFormat{i} = cat(1, '<undefined>', categories(categoricalObject));
+                end
+            end
+
+            if ~isempty(obj.MetaTableVariableAttributes)
+                isVarWithOptions = [obj.MetaTableVariableAttributes.HasOptions];
+                isValidType = strcmp([obj.MetaTableVariableAttributes.TableType], obj.MetaTableType);
+                customVarNames = {obj.MetaTableVariableAttributes(isVarWithOptions & isValidType).Name};
+                [customVarNames, iA] = intersect(variableNames, customVarNames);
+
+                for i = 1:numel(customVarNames)
+                    thisName = customVarNames{i};
+                    tableVarIndex = strcmp({obj.MetaTableVariableAttributes.Name}, thisName);
+                    popupOptions = obj.MetaTableVariableAttributes(tableVarIndex).OptionsList;
+
+                    if isa(popupOptions, 'cell') && numel(popupOptions) == 1
+                        columnFormat(iA(i)) = popupOptions;
+                    else
+                        columnFormat(iA(i)) = {popupOptions};
+                    end
+                    obj.HTable.ColumnEditable(iA(i)) = true;
+                end
+            end
+
+            if any(strcmp(dataTypes, 'cell'))
+                error('The table contains values that can not be rendered. Please contact support.')
+            end
+
+            obj.HTable.ColumnFormat = columnFormat;
+            obj.HTable.ColumnName = columnLabels;
+            obj.applyHtmlInterpreterStyles()
+            obj.ColumnModel.updateJavaColumnModel()
+        end
+
+        function updateColumnLabelFilterIndicator(obj, filterActive)
+            if nargin < 2
+                filterActive = obj.ColumnFilter.isColumnFilterActive;
+            end
+
+            colIndices = obj.ColumnModel.getColumnIndices();
+            if ~isempty(filterActive)
+                filterActive = filterActive(colIndices);
+            end
+
+            columnNames = obj.ColumnModel.getColumnNames();
+            for i = 1:numel(columnNames)
+                if ~isempty(filterActive) && filterActive(i)
+                    columnNames{i} = sprintf('* %s', columnNames{i});
+                end
+            end
+            if ~isempty(columnNames)
+                obj.changeColumnNames(columnNames)
+            end
+        end
+
+        function updateColumnEditable(obj)
+            if isempty(obj.ColumnModel) || isempty(obj.MetaTableVariableAttributes)
+                return
+            end
+
+            allowEdit = obj.ColumnModel.getColumnIsEditable;
+            [~, variableNames] = obj.ColumnModel.getColumnNames();
+            attributeColumnNames = {obj.MetaTableVariableAttributes.Name};
+            [isMatched, attributeIdx] = ismember(variableNames, attributeColumnNames);
+
+            isEditable = false(size(allowEdit));
+            if any(isMatched)
+                isEditable(isMatched) = [obj.MetaTableVariableAttributes(attributeIdx(isMatched)).IsEditable];
+            end
+            allowEdit = allowEdit & isEditable;
+
+            columnNames = obj.ColumnModel.getColumnNames();
+            if obj.AllowTableEdits
+                allowEdit(contains(lower(columnNames), 'ignore')) = true;
+                allowEdit(contains(lower(columnNames), 'description')) = true;
+            else
+                allowEdit(:) = false;
+            end
+
+            obj.HTable.ColumnEditable = allowEdit;
+        end
+
+        function C = getDisplayTableData(obj, rowIndices, columnIndices)
+            C = obj.MetaTableCell(rowIndices, columnIndices);
+            C = cellfun(@obj.normalizeDisplayValue, C, 'UniformOutput', false);
+        end
+
+        function changeColumnNames(obj, newNames)
+            obj.HTable.ColumnName = newNames;
+        end
+
+        function changeColumnWidths(obj, newWidths)
+            obj.HTable.ColumnWidth = num2cell(newWidths);
+        end
+    end
+
+    methods (Access = private)
+        function parseInputs(obj, listOfArgs)
+            [nvPairs, remainingArgs] = utility.getnvpairs(listOfArgs);
+
+            for i = 1:2:numel(nvPairs)
+                if isprop(obj, nvPairs{i})
+                    obj.(nvPairs{i}) = nvPairs{i+1};
+                end
+            end
+
+            if isempty(remainingArgs)
+                return
+            end
+
+            if isgraphics(remainingArgs{1})
+                obj.Parent = remainingArgs{1};
+                remainingArgs = remainingArgs(2:end);
+            end
+
+            if isempty(remainingArgs)
+                return
+            end
+
+            if obj.isValidTableClass(remainingArgs{1})
+                obj.MetaTable = remainingArgs{1};
+            end
+        end
+
+        function createUiTable(obj)
+            if isempty(obj.Parent)
+                obj.Parent = uifigure(...
+                    'Name', 'NANSEN Metadata Table', ...
+                    'Visible', 'on');
+            end
+
+            obj.HTable = uitable(obj.Parent, ...
+                'Tag', 'MetaTable', ...
+                'FontSize', obj.TableFontSize, ...
+                'FontName', 'avenir next', ...
+                'Units', 'normalized', ...
+                'Position', [0 0 1 1], ...
+                'Visible', 'off');
+
+            obj.HTable.ColumnEditable = true;
+            obj.HTable.ColumnSortable = true;
+            obj.HTable.ColumnRearrangeable = true;
+            obj.HTable.SelectionType = 'row';
+            obj.HTable.Multiselect = 'on';
+            obj.HTable.CellEditCallback = @obj.onCellValueEdited;
+            obj.HTable.SelectionChangedFcn = @obj.onCellSelectionChanged;
+            obj.HTable.DisplayDataChangedFcn = @obj.onDisplayDataChanged;
+            obj.HTable.DoubleClickedFcn = @obj.onMouseDoubleClickedInTable;
+            obj.HTable.ContextMenu = obj.TableContextMenu;
+        end
+
+        function onMetaTableSet(obj, newTable)
+            if isa(newTable, 'nansen.metadata.MetaTable')
+                T = newTable.getFormattedTableData([], [], 'modern');
+                obj.MetaTableType = lower(newTable.getTableType());
+                obj.MetaTableCell = table2cell(T);
+            elseif isa(newTable, 'table')
+                obj.MetaTableCell = table2cell(newTable);
+            end
+
+            if ~isempty(obj.MetaTable)
+                obj.MetaTableVariableNames = obj.MetaTable.Properties.VariableNames;
+            else
+                obj.MetaTableVariableNames = {};
+            end
+
+            obj.MetaTableVariableAttributes = obj.getMetaTableVariableAttributes();
+        end
+
+        function onTableVariableAttributesFcnSet(obj)
+            obj.MetaTableVariableAttributes = obj.getMetaTableVariableAttributes();
+            if obj.IsConstructed
+                obj.updateColumnLayout()
+            end
+        end
+
+        function onTableFontSizeSet(obj)
+            if ~isempty(obj.HTable)
+                obj.HTable.FontSize = obj.TableFontSize;
+            end
+        end
+
+        function onColumnFilterSet(obj)
+            if ~isempty(obj.FilterChangedListener)
+                delete(obj.FilterChangedListener)
+            end
+
+            obj.FilterChangedListener = addlistener(obj.ColumnFilter, ...
+                'FilterUpdated', @obj.onFilterUpdated);
+        end
+
+        function applyHtmlInterpreterStyles(obj)
+            obj.removeHtmlInterpreterStyles()
+
+            if isempty(obj.HTable) || ~isvalid(obj.HTable) || ...
+                    isempty(obj.ColumnModel) || isempty(obj.MetaTableCell)
+                return
+            end
+
+            visibleColumns = obj.ColumnModel.getColumnIndices();
+            htmlColumns = false(1, numel(visibleColumns));
+            for i = 1:numel(visibleColumns)
+                htmlColumns(i) = obj.isHtmlFormattedColumn(visibleColumns(i));
+            end
+
+            if ~any(htmlColumns)
+                return
+            end
+
+            htmlStyle = uistyle('Interpreter', 'html');
+            addStyle(obj.HTable, htmlStyle, 'column', find(htmlColumns))
+            obj.HtmlStyleConfigurationRows = height(obj.HTable.StyleConfigurations);
+        end
+
+        function removeHtmlInterpreterStyles(obj)
+            if isempty(obj.HtmlStyleConfigurationRows) || ...
+                    isempty(obj.HTable) || ~isvalid(obj.HTable) || ...
+                    ~isprop(obj.HTable, 'StyleConfigurations')
+                obj.HtmlStyleConfigurationRows = [];
+                return
+            end
+
+            try
+                styleRows = obj.HtmlStyleConfigurationRows;
+                styleRows = styleRows(styleRows <= height(obj.HTable.StyleConfigurations));
+                if ~isempty(styleRows)
+                    removeStyle(obj.HTable, styleRows)
+                end
+            catch
+            end
+
+            obj.HtmlStyleConfigurationRows = [];
+        end
+
+        function tf = isHtmlFormattedColumn(obj, columnIndex)
+            columnValues = obj.MetaTableCell(:, columnIndex);
+            tf = any(cellfun(@obj.isHtmlFormattedValue, columnValues));
+        end
+
+        function tf = isHtmlFormattedValue(~, value)
+            if isstring(value) && isscalar(value)
+                value = char(value);
+            end
+
+            tf = ischar(value) && startsWith(strtrim(value), '<html', ...
+                'IgnoreCase', true);
+        end
+
+        function onFilterUpdated(obj, ~, ~)
+            obj.updateTableView([], false)
+
+            if ~isempty(obj.ExternalFilterMap)
+                visibleRows = find(obj.ExternalFilterMap);
+            else
+                visibleRows = 1:size(obj.MetaTableCell, 1);
+            end
+
+            rows = obj.getCurrentRowSelection();
+            rows = intersect(rows, visibleRows, 'stable');
+
+            evtdata = uiw.event.EventData('RowIndices', rows, 'Type', 'TableFilterUpdate');
+            obj.notify('TableUpdated', evtdata)
+        end
+
+        function rowInd = getCurrentRowSelection(obj)
+            [numRows, numColumns] = size(obj.MetaTableCell);
+            if isempty(obj.DataFilterMap)
+                obj.DataFilterMap = true(numRows, numColumns);
+            end
+
+            if ~obj.ShowIgnoredEntries && ~isempty(obj.MetaTable)
+                varNames = obj.MetaTable.Properties.VariableNames;
+                isIgnoreColumn = contains(lower(varNames), 'ignore');
+                if any(isIgnoreColumn)
+                    isIgnored = [obj.MetaTableCell{:, isIgnoreColumn}];
+                    obj.DataFilterMap(:, isIgnoreColumn) = ~isIgnored;
+                end
+            end
+
+            rowInd = find(all(obj.DataFilterMap, 2));
+
+            if ~isempty(obj.ExternalFilterMap)
+                rowInd = intersect(rowInd, find(obj.ExternalFilterMap), 'stable');
+            end
+        end
+
+        function colInd = getCurrentColumnSelection(obj)
+            if isempty(obj.ColumnModel)
+                colInd = [];
+                return
+            end
+
+            colInd = obj.ColumnModel.getColumnIndices();
+        end
+
+        function updateMetaTableVariableAttributes(obj)
+            obj.MetaTableVariableAttributes = obj.getMetaTableVariableAttributes();
+        end
+
+        function S = getMetaTableVariableAttributes(obj)
+            if isempty(obj.MetaTable)
+                S = struct.empty;
+            elseif ~isempty(obj.GetTableVariableAttributesFcn)
+                S = obj.GetTableVariableAttributesFcn(obj.MetaTableType);
+            else
+                S = obj.getDefaultMetaTableVariableAttributes();
+            end
+        end
+
+        function S = getDefaultMetaTableVariableAttributes(obj)
+            import nansen.metadata.abstract.TableVariable;
+
+            if isempty(obj.MetaTable)
+                S = struct.empty;
+                return
+            end
+
+            varNames = obj.MetaTable.Properties.VariableNames;
+            numVars = numel(varNames);
+            S = TableVariable.getDefaultTableVariableAttribute();
+            S = repmat(S, 1, numVars);
+
+            [S(1:numVars).Name] = varNames{:};
+            [S(1:numVars).TableType] = deal(obj.MetaTableType);
+        end
+
+        function value = normalizeDisplayValue(obj, value)
+            % Web uitable cells can only contain numeric, logical or char values.
+            if ischar(value)
+                return
+            elseif isnumeric(value) || islogical(value)
+                if isscalar(value) || isempty(value)
+                    return
+                else
+                    value = mat2str(value);
+                end
+            else
+                value = obj.stringifyDisplayValue(value);
+            end
+        end
+
+        function str = stringifyDisplayValue(obj, value)
+            if isempty(value)
+                str = '';
+            elseif iscell(value)
+                str = obj.stringifyCellValue(value);
+            elseif isstring(value) || isdatetime(value) || isduration(value) || ...
+                    iscategorical(value) || isenum(value)
+                str = obj.stringifyStringConvertibleValue(value);
+            elseif isstruct(value)
+                str = strtrim(evalc('disp(value)'));
+            else
+                try
+                    str = char(value);
+                catch
+                    str = strtrim(evalc('disp(value)'));
+                end
+            end
+        end
+
+        function str = stringifyCellValue(obj, value)
+            if isempty(value)
+                str = '';
+                return
+            end
+
+            parts = cellfun(@obj.stringifyDisplayValue, value(:), ...
+                'UniformOutput', false);
+            str = char(strjoin(string(parts), ', '));
+        end
+
+        function str = stringifyStringConvertibleValue(~, value)
+            if isscalar(value)
+                str = char(value);
+            else
+                str = char(strjoin(string(value(:).'), ', '));
+            end
+        end
+
+        function onCellValueEdited(obj, ~, evtData)
+            rowInd = obj.DisplayRowIndex;
+            colInd = obj.DisplayColumnIndex;
+
+            tableRowInd = rowInd(evtData.Indices(1));
+            tableColInd = colInd(evtData.Indices(2));
+
+            obj.MetaTableCell{tableRowInd, tableColInd} = evtData.NewData;
+
+            if ~isempty(obj.CellEditCallback)
+                evt = uiw.event.EventData(...
+                    'Indices', [tableRowInd, tableColInd], ...
+                    'NewValue', evtData.NewData, ...
+                    'PreviousValue', evtData.PreviousData);
+                obj.CellEditCallback(obj.HTable, evt)
+            end
+        end
+
+        function onCellSelectionChanged(obj, ~, ~)
+            selectedRows = obj.getSelectedEntries();
+            evtData = uiw.event.EventData('SelectedRows', selectedRows);
+            obj.notify('SelectionChanged', evtData)
+        end
+
+        function onDisplayDataChanged(obj, ~, evt)
+            if isprop(evt, 'Interaction') && strcmp(evt.Interaction, 'rearrange')
+                try
+                    obj.ColumnModel.setNewColumnOrder(evt.DisplayColumnName)
+                catch
+                    % Native table callback metadata varies by release.
+                end
+            end
+        end
+
+        function onMouseDoubleClickedInTable(obj, src, evt)
+            if isempty(obj.MouseDoubleClickedFcn)
+                return
+            end
+
+            cellIndex = obj.getCellFromInteractionEvent(evt);
+            if any(cellIndex == 0)
+                return
+            end
+
+            evtData = uiw.event.EventData(...
+                'Cell', cellIndex, ...
+                'SelectionType', 'open', ...
+                'Button', 1, ...
+                'Position', [0 0], ...
+                'MetaOn', false, ...
+                'ControlOn', false);
+
+            obj.MouseDoubleClickedFcn(src, evtData)
+        end
+
+        function cellIndex = getCellFromInteractionEvent(obj, evt)
+            row = [];
+            col = [];
+
+            if isprop(evt, 'InteractionInformation')
+                info = evt.InteractionInformation;
+                row = obj.getInteractionProperty(info, 'Row');
+                col = obj.getInteractionProperty(info, 'Column');
+            end
+
+            if isempty(row) || isempty(col)
+                selection = obj.HTable.Selection;
+                if isempty(selection)
+                    cellIndex = [0 0];
+                    return
+                elseif size(selection, 2) == 2
+                    row = selection(1,1);
+                    col = selection(1,2);
+                else
+                    row = selection(1);
+                    col = 1;
+                end
+            end
+
+            cellIndex = [row, col];
+        end
+
+        function value = getInteractionProperty(~, info, propertyName)
+            value = [];
+            try
+                if isprop(info, propertyName)
+                    value = info.(propertyName);
+                elseif isstruct(info) && isfield(info, propertyName)
+                    value = info.(propertyName);
+                end
+            catch
+                value = [];
+            end
+        end
+
+        function selectedRows = getSelectedViewRows(obj)
+            selection = obj.HTable.Selection;
+            if isempty(selection)
+                selectedRows = [];
+            elseif strcmp(obj.HTable.SelectionType, 'row')
+                selectedRows = selection(:);
+            elseif isvector(selection)
+                selectedRows = selection(:);
+            elseif size(selection, 2) == 2
+                selectedRows = selection(:,1);
+            else
+                selectedRows = selection;
+            end
+        end
+
+        function columnWidths = normalizeColumnWidths(~, columnWidths)
+            if iscell(columnWidths)
+                isNumericWidth = cellfun(@isnumeric, columnWidths);
+                numericWidths = columnWidths(isNumericWidth);
+                if isempty(numericWidths)
+                    columnWidths = [];
+                else
+                    columnWidths = [numericWidths{:}];
+                end
+            end
+        end
+
+    end
+
+    methods (Static)
+        function tf = isValidTableClass(var)
+            validClasses = nansen.ui.metatable.ModernUiMetaTableViewer.VALID_TABLE_CLASS;
+            tf = any(cellfun(@(type) isa(var, type), validClasses));
+        end
+    end
+end

--- a/code/+nansen/+ui/MetaTableColumnLayout.m
+++ b/code/+nansen/+ui/MetaTableColumnLayout.m
@@ -233,8 +233,17 @@ classdef MetaTableColumnLayout < nansen.mixin.UserSettings
             % Also, need to call this whenever a table variable was edited in 
             % sessionbrowser/nansen and when new tables are loaded.
             
-            p = nansen.getCurrentProject();
-            % Return early if no project is active.
+            try
+                p = nansen.getCurrentProject();
+            catch ME
+                if strcmp(ME.identifier, 'NANSEN:NoActiveUserSession')
+                    % Standalone metatable viewers keep their existing
+                    % default editability when no project metadata exists.
+                    return
+                else
+                    rethrow(ME)
+                end
+            end
             if isempty(p); return; end
 
             tableVariableAttributes = p.getTable('TableVariable');
@@ -482,9 +491,40 @@ classdef MetaTableColumnLayout < nansen.mixin.UserSettings
                     
             obj.updateUiTableEditor()
         end
+
+        function setNewColumnVariableOrder(obj, newVariableOrder)
+        %setNewColumnVariableOrder Update visible column order by variable name.
+            IND = getIndicesToShowInMetaTable(obj);
+            if isempty(IND); return; end
+
+            currentVariableNames = string({obj.settings(IND).VariableName});
+            newVariableOrder = string(newVariableOrder(:)).';
+            if numel(newVariableOrder) ~= numel(currentVariableNames)
+                return
+            end
+
+            [isVisibleVariable, newPosition] = ismember( ...
+                currentVariableNames, newVariableOrder);
+            if ~all(isVisibleVariable) || any(newPosition == 0)
+                return
+            end
+
+            visibleOrder = sort([obj.settings(IND).ColumnOrder]);
+            for i = 1:numel(IND)
+                obj.settings_(IND(i)).ColumnOrder = visibleOrder(newPosition(i));
+            end
+
+            obj.updateUiTableEditor()
+        end
         
         function updateJavaColumnModel(obj)
             
+            if ~obj.hasJavaColumnModel()
+                obj.JColumnModel = [];
+                obj.JColumnModelIndices = 1:numel(obj.getColumnIndices());
+                return
+            end
+
             if isempty(obj.JColumnModel)
                 obj.JColumnModel = obj.MetaTableUi.HTable.JTable.getTableHeader.getColumnModel;
             end
@@ -501,6 +541,10 @@ classdef MetaTableColumnLayout < nansen.mixin.UserSettings
         
         function idx = getColumnIdx(obj, idx)
             
+            if ~obj.hasJavaColumnModel()
+                return
+            end
+
             numColumns = get(obj.JColumnModel, 'ColumnCount');
             for i = 1:numColumns
                 jColumn = obj.JColumnModel.getColumn(i-1);
@@ -514,6 +558,15 @@ classdef MetaTableColumnLayout < nansen.mixin.UserSettings
         
         function [colIndex, colNames] = getColumnModelIndexOrder(obj)
             
+            if ~obj.hasJavaColumnModel()
+                colIndex = 1:numel(obj.getColumnIndices());
+                colNames = obj.getColumnNames();
+                if nargout == 1
+                    clear colNames
+                end
+                return
+            end
+
             numColumns = get(obj.JColumnModel, 'ColumnCount');
             colIndex = zeros(1, numColumns);
             colNames = cell(1, numColumns);
@@ -567,27 +620,37 @@ classdef MetaTableColumnLayout < nansen.mixin.UserSettings
             tmpF.NumberTitle = 'off';
             tmpF.Name = 'Edit Column Layout';
             tmpF.MenuBar = 'none';
-            tmpF.Resize = 'off';
+            tmpF.Resize = 'on';
             
             % Create table
             tmpTable = uitable('Parent', tmpF);
             tmpTable.FontSize = 12;
             tmpTable.FontName = 'Avenir New';
-            tmpTable.ColumnWidth = {150, 150, 100, 100};
+            columnWidths = {170, 220, 90, 110, 90};
+            tmpTable.ColumnWidth = columnWidths;
             tmpTable.Data = table2cell(T);
             tmpTable.ColumnName = T.Properties.VariableNames;
-            tmpTable.ColumnEditable = [false true true true];
-            tmpTable.Position = tmpTable.Extent;
+            tmpTable.ColumnEditable = [false true true true true];
+            tmpTable.Units = 'normalized';
+            tmpTable.Position = [0 0 1 1];
             tmpTable.CellEditCallback = @obj.onSettingsChanged;
             
             obj.UIEditorFigure = tmpF;
             obj.UIEditorTable = tmpTable;
             
-            % Set figure position same as figure extent and make visible
-            tmpF.Position(3:4) = tmpTable.Extent(3:4);
+            % Size the editor to show all rows when it fits on screen.
+            screenSize = get(0, 'ScreenSize');
+            rowHeight = 24;
+            headerHeight = 38;
+            margin = 24;
+            preferredWidth = sum([columnWidths{:}]) + 80;
+            preferredHeight = headerHeight + height(T) * rowHeight + margin;
+            figureWidth = min(max(preferredWidth, 720), floor(screenSize(3) * 0.9));
+            figureHeight = min(max(preferredHeight, 320), floor(screenSize(4) * 0.85));
+            figureX = screenSize(1) + round((screenSize(3) - figureWidth) / 2);
+            figureY = screenSize(2) + round((screenSize(4) - figureHeight) / 2);
+            tmpF.Position = [figureX, figureY, figureWidth, figureHeight];
             tmpF.Visible = 'on';
-
-            % Todo: Make sure figure is not taller than the screen size.
             
             % Wait for figure...
             uiwait(tmpF)
@@ -598,6 +661,21 @@ classdef MetaTableColumnLayout < nansen.mixin.UserSettings
             if ~isempty(obj.UIEditorTable)
                 T = getTableDataForUiEditor(obj);
                 obj.UIEditorTable.Data = table2cell(T);
+            end
+        end
+
+        function tf = hasJavaColumnModel(obj)
+            tf = false;
+            if isempty(obj.MetaTableUi) || isempty(obj.MetaTableUi.HTable)
+                return
+            end
+            if ~isprop(obj.MetaTableUi.HTable, 'JTable')
+                return
+            end
+            try
+                tf = ~isempty(obj.MetaTableUi.HTable.JTable);
+            catch
+                tf = false;
             end
         end
     end
@@ -851,7 +929,15 @@ classdef MetaTableColumnLayout < nansen.mixin.UserSettings
             
             tf = false;
             
-            customVarNames = getCustomTableVariableNames();
+            try
+                customVarNames = getCustomTableVariableNames();
+            catch ME
+                if strcmp(ME.identifier, 'NANSEN:NoActiveUserSession')
+                    return
+                else
+                    rethrow(ME)
+                end
+            end
             
             if ~contains(variableName, customVarNames)
                 return

--- a/code/+nansen/+util/ensureEntityTableOnPath.m
+++ b/code/+nansen/+util/ensureEntityTableOnPath.m
@@ -1,0 +1,79 @@
+function ensureEntityTableOnPath()
+%ensureEntityTableOnPath Ensure the R2025+ table component is available.
+
+    if isEntityTableAvailable()
+        return
+    end
+
+    candidatePaths = getCandidatePaths();
+    for i = 1:numel(candidatePaths)
+        thisPath = normalizeCandidatePath(candidatePaths{i});
+        if isempty(thisPath) || ~isfolder(thisPath)
+            continue
+        end
+
+        addpath(thisPath)
+        rehash()
+        if isEntityTableAvailable()
+            return
+        end
+    end
+
+    error('NANSEN:MissingEntityTable', ...
+        ['The R2025a+ metadata table backend requires entity-table. ', ...
+         'Install https://github.com/ehennestad/entity-table or add its ', ...
+         'src/entitytable folder to the MATLAB path.'])
+end
+
+function tf = isEntityTableAvailable()
+    tf = exist('entitytable.EntityTableView', 'class') == 8 || ...
+        ~isempty(which('entitytable.EntityTableView'));
+end
+
+function candidatePaths = getCandidatePaths()
+    nansenRoot = fileparts(nansen.toolboxdir());
+    matlabRoot = findAncestorNamed(nansenRoot, 'MATLAB');
+
+    candidatePaths = { ...
+        getenv('ENTITY_TABLE_PATH'), ...
+        fullfile(userpath(), 'NANSEN', 'Requirements', 'entity-table'), ...
+        fullfile(nansenRoot, 'external', 'entity-table'), ...
+        fullfile(fileparts(nansenRoot), 'entity-table') ...
+        };
+
+    if ~isempty(matlabRoot)
+        candidatePaths{end+1} = fullfile(matlabRoot, ...
+            'General', 'Repositories', 'ehennestad', 'entity-table');
+    end
+end
+
+function folderPath = normalizeCandidatePath(folderPath)
+    if isempty(folderPath)
+        return
+    end
+
+    if isfolder(fullfile(folderPath, '+entitytable'))
+        return
+    end
+
+    if isfolder(fullfile(folderPath, 'src', 'entitytable', '+entitytable'))
+        folderPath = fullfile(folderPath, 'src', 'entitytable');
+    elseif isfolder(fullfile(folderPath, 'src', '+entitytable'))
+        folderPath = fullfile(folderPath, 'src');
+    end
+end
+
+function ancestorPath = findAncestorNamed(folderPath, folderName)
+    ancestorPath = '';
+    while ~isempty(folderPath)
+        [parentPath, name] = fileparts(folderPath);
+        if strcmp(name, folderName)
+            ancestorPath = folderPath;
+            return
+        end
+        if strcmp(parentPath, folderPath)
+            return
+        end
+        folderPath = parentPath;
+    end
+end

--- a/code/+nansen/+util/useModernUiTable.m
+++ b/code/+nansen/+util/useModernUiTable.m
@@ -1,0 +1,5 @@
+function tf = useModernUiTable()
+%useModernUiTable True when NANSEN should use Java-free table components.
+
+    tf = nansen.util.useModernUiComponents();
+end

--- a/code/apps/+imviewer/+widget/DraggableThumbnail.m
+++ b/code/apps/+imviewer/+widget/DraggableThumbnail.m
@@ -16,8 +16,14 @@ classdef DraggableThumbnail < handle
     methods
         
         function obj = DraggableThumbnail(hFig, im, initPos, cMap)
-            warning('off', 'MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame');
-            warning('off', 'MATLAB:ui:javaframe:PropertyToBeRemoved')
+
+            if ~nansen.util.isJavaFrameSupported()
+                error('NANSEN:Imviewer:DraggableThumbnailNotSupported', ...
+                    'This widget is not supported on the current MATLAB release')
+            end
+
+            warningCleanup = nansen.ui.legacy.tempDisableJavaFrameWarnings(); %#ok<NASGU>
+
             screenSize = get(0, 'ScreenSize');
             
             sz = [128, 128];
@@ -27,7 +33,7 @@ classdef DraggableThumbnail < handle
             x = hFig.Position(1) + hFig.Position(3)/2;
             y = hFig.Position(2) + hFig.Position(4)/2;
             
-            jFrame = get(hFig, 'JavaFrame');
+            jFrame = get(hFig, 'JavaFrame'); %#ok<JAVFM>
             jClient = jFrame.fHG2Client;
             jWindow = jClient.getWindow;
             jWindow.setAlwaysOnTop(true)
@@ -65,8 +71,6 @@ classdef DraggableThumbnail < handle
             obj.initPosJava = [x,y];
             
             %obj.startMoveWindow
-            warning('on', 'MATLAB:HandleGraphics:ObsoletedProperty:JavaFrame');
-            warning('on', 'MATLAB:ui:javaframe:PropertyToBeRemoved')
             
             obj.hFigure.WindowButtonUpFcn = @obj.stopMoveWindow;
 

--- a/code/apps/+imviewer/@App/App.m
+++ b/code/apps/+imviewer/@App/App.m
@@ -260,9 +260,7 @@ methods % Structors
         % function will change dramatically later...
         % obj.parseVarargin(varargin{:})
         
-        warning('off', 'MATLAB:ui:javaframe:PropertyToBeRemoved')
         obj.initializeViewer()
-        warning('on', 'MATLAB:ui:javaframe:PropertyToBeRemoved')
         
         setappdata(obj.Figure, 'ViewerObject', obj)
         

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -1339,8 +1339,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
 
         function position = getComponentParentContentPosition(~, hComponent)
             parent = hComponent.Parent;
-            if isa(parent, 'matlab.ui.container.Tab') ...
-                    && exist('uim.utility.getContentPixelPosition', 'file') == 2
+            if isa(parent, 'matlab.ui.container.Tab')
                 position = uim.utility.getContentPixelPosition(parent);
             else
                 try

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -155,7 +155,6 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             end
 
             % % Start app construction
-            app.switchJavaWarnings('off')
             app.configureWindow()
             app.lockWindowPosition()
            
@@ -189,8 +188,6 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             app.StatusItems = containers.Map;
             
             app.unlockWindowPosition()
-
-            app.switchJavaWarnings('on')
             
             % Add this callback after every component is made
             app.Figure.SizeChangedFcn = @(s, e) app.onFigureSizeChanged;
@@ -371,6 +368,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             if nansen.util.isJavaFrameSupported()
                 % Configure figure window to have a minimum allowed size.
                 minimumFigureSize = app.getPreference('MinimumFigureSize');
+                warningCleanup = nansen.ui.legacy.tempDisableJavaFrameWarnings(); %#ok<NASGU>
                 LimitFigSize(app.Figure, 'min', minimumFigureSize) % FEX
             end
         end
@@ -2067,7 +2065,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
 % % %             persistent lastKeyPressTime
 % % %             if isempty(lastKeyPressTime); lastKeyPressTime = tic; end
 
-            if isa(evt, 'java.awt.event.KeyEvent')
+            if nansen.util.isJavaFrameSupported() && isa(evt, 'java.awt.event.KeyEvent')
                 evt = uim.event.javaKeyEventToMatlabKeyData(evt);
             end
 
@@ -2111,7 +2109,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         
         function onKeyReleased(app, ~, evt)
 
-            if isa(evt, 'java.awt.event.KeyEvent')
+            if nansen.util.isJavaFrameSupported() && isa(evt, 'java.awt.event.KeyEvent')
                 evt = uim.event.javaKeyEventToMatlabKeyData(evt);
             end
             
@@ -4496,12 +4494,6 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                     hApp.onExit(matchedFigure)
                 end
             end
-        end
-
-        function switchJavaWarnings(newState)
-        %switchJavaWarnings Turn warnings about java functionality on/off
-            warning(newState, 'MATLAB:ui:javaframe:PropertyToBeRemoved')
-            warning(newState, 'MATLAB:ui:javacomponent:FunctionToBeRemoved')
         end
 
         function pathStr = getIconPath()

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -1327,14 +1327,24 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             % Todo: Get the padding value programmatically
             xPadding = 3;
             
-            parentPosition = app.getComponentParentContentPosition(uiTable.HTable);
+            if uiTable.usesModernBackend()
+                parentPosition = app.getComponentParentContentPosition(uiTable.HTable);
 
-            tablePosition = parentPosition;
-            tablePosition(1) = parentPosition(1) + w + xPadding;
-            tablePosition(3) = max(1, ...
-                parentPosition(3) - (w + xPadding + 1));
-            app.setComponentPixelPosition(uiTable.HTable, tablePosition)
-            uiTable.fitColumnsToTableWidth()
+                tablePosition = parentPosition;
+                tablePosition(1) = parentPosition(1) + w + xPadding;
+                tablePosition(3) = max(1, ...
+                    parentPosition(3) - (w + xPadding + 1));
+                app.setComponentPixelPosition(uiTable.HTable, tablePosition)
+                uiTable.fitColumnsToTableWidth()
+            else
+                parentPosition = getpixelposition(uiTable.HTable.Parent);
+
+                tablePosition = getpixelposition(uiTable.HTable);
+                tablePosition(1) = w + xPadding;
+                tablePosition(3) = max(1, ...
+                    parentPosition(3) - (w + xPadding + 1));
+                setpixelposition(uiTable.HTable, tablePosition)
+            end
         end
 
         function position = getComponentParentContentPosition(~, hComponent)
@@ -2300,7 +2310,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                     if isempty(app.UiMetaTableViewer)
                         numItemsTotal = size(app.MetaTable.entries, 1);
                     else
-                        numItemsTotal = size(app.UiMetaTableViewer.HTable.Data, 1);
+                        numItemsTotal = app.UiMetaTableViewer.getDisplayedRowCount();
                     end
                 end
 
@@ -2313,7 +2323,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                     if isempty(app.UiMetaTableViewer)
                         numItemsSelected = 0;
                     else
-                        numItemsSelected = numel(app.UiMetaTableViewer.HTable.SelectedRows);
+                        numItemsSelected = app.UiMetaTableViewer.getSelectedRowCount();
                     end
                 end
 
@@ -2379,7 +2389,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         function onTableItemSelectionChanged(app, src, evt)
         %onTableItemSelectionChanged Callback for meta table
             numItemsSelected = numel(evt.SelectedRows);
-            numItemsTotal = size(src.HTable.Data, 1);
+            numItemsTotal = src.getDisplayedRowCount();
             
             app.updateTableItemCount(numItemsTotal, numItemsSelected)
             app.updateCustomRowSelectionStatus()

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -368,9 +368,11 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                 app.Figure.Position = prefScreenPos{screenNumber};
             end
 
-            % Configure figure window to have a minimum allowed size.
-            minimumFigureSize = app.getPreference('MinimumFigureSize');
-            LimitFigSize(app.Figure, 'min', minimumFigureSize) % FEX
+            if nansen.util.isJavaFrameSupported()
+                % Configure figure window to have a minimum allowed size.
+                minimumFigureSize = app.getPreference('MinimumFigureSize');
+                LimitFigSize(app.Figure, 'min', minimumFigureSize) % FEX
+            end
         end
         
         function lockWindowPosition(app)
@@ -388,9 +390,12 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             app.Figure.WindowKeyPressFcn = @app.onKeyPressed;
             app.Figure.WindowKeyReleaseFcn = @app.onKeyReleased;
             
-            [~, hJ] = evalc('findjobj(app.Figure)');
-            hJ(2).KeyPressedCallback = @app.onKeyPressed;
-            hJ(2).KeyReleasedCallback = @app.onKeyReleased;
+            if nansen.util.isJavaFrameSupported
+                warnCleanup = nansen.ui.legacy.tempDisableJavaFrameWarnings(); %#ok<NASGU>
+                [~, hJ] = evalc('findjobj(app.Figure)');
+                hJ(2).KeyPressedCallback = @app.onKeyPressed;
+                hJ(2).KeyReleasedCallback = @app.onKeyReleased;
+            end
         end
                 
         function createLayout(app)

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -1062,14 +1062,17 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         function hContextMenu = createSessionTableContextMenu(app)
         %createSessionTableContextMenu Create a context menu for sessions in table
             
-            hContextMenu = uicontextmenu(app.Figure);
+            hContextMenuParent = ancestor(app.UiMetaTableViewer.HTable, 'figure');
+            if isempty(hContextMenuParent)
+                hContextMenuParent = app.Figure;
+            end
+            hContextMenu = uicontextmenu(hContextMenuParent);
             % hContextMenu.ContextMenuOpeningFcn = @(s,e,m) disp('test');%onContextMenuOpening;
         
             % Delete context menu if it exists from before:
             if ~isempty(app.UiMetaTableViewer.TableContextMenu)
                 delete(app.UiMetaTableViewer.TableContextMenu)
             end
-            app.UiMetaTableViewer.TableContextMenu = hContextMenu;
             
             hMenuItem = gobjects(0);
             c = 1;
@@ -1155,8 +1158,10 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         
             % Disable context menu if current type is not a session
             metaTableType = app.CurrentItemType;
-            if ~strcmpi(metaTableType, 'session')
-                app.disableSessionContextMenu()
+            if strcmpi(metaTableType, 'session')
+                app.UiMetaTableViewer.TableContextMenu = hContextMenu;
+            else
+                app.UiMetaTableViewer.TableContextMenu = [];
             end
         end
         
@@ -1245,18 +1250,15 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             app.UiMetaTableViewer = h;
             h.CellEditCallback = @app.onMetaTableDataChanged;
             
-            % Add keypress callback to uiw.Table object
-            h.HTable.KeyPressFcn = @app.onKeyPressed;
-            % h.HTable.MouseMotionFcn = @(s,e) onMouseMotionInTable(h, s, e);
-            
-            addlistener(h.HTable, 'MouseMotion', @app.onMouseMoveInTable);
+            h.setKeyPressFcn(@app.onKeyPressed);
+            h.addMouseMotionCallback(@app.onMouseMoveInTable);
             
             h.UpdateColumnFcn = @app.updateTableVariable;
             h.ResetColumnFcn = @app.resetTableVariable;
             h.DeleteColumnFcn = @app.removeTableVariable;
             h.EditColumnFcn = @app.editTableVariableFunction;
 
-            h.GetTableVariableAttributesFcn = @(s,e) app.getTableVariableAttributes();
+            h.GetTableVariableAttributesFcn = @(varargin) app.getTableVariableAttributes();
 
             h.MouseDoubleClickedFcn = @app.onMouseDoubleClickedInTable;
             
@@ -1320,13 +1322,36 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             % Todo: Get the padding value programmatically
             xPadding = 3;
             
-            parentPosition = getpixelposition(uiTable.HTable.Parent);
-            panelWidth = parentPosition(3);
+            parentPosition = app.getComponentParentContentPosition(uiTable.HTable);
 
-            tablePosition = getpixelposition(uiTable.HTable);
-            tablePosition(1) = w + xPadding;
-            tablePosition(3) = panelWidth - (w + xPadding + 1);
-            setpixelposition(uiTable.HTable, tablePosition)
+            tablePosition = parentPosition;
+            tablePosition(1) = parentPosition(1) + w + xPadding;
+            tablePosition(3) = max(1, ...
+                parentPosition(3) - (w + xPadding + 1));
+            app.setComponentPixelPosition(uiTable.HTable, tablePosition)
+            uiTable.fitColumnsToTableWidth()
+        end
+
+        function position = getComponentParentContentPosition(~, hComponent)
+            parent = hComponent.Parent;
+            if isa(parent, 'matlab.ui.container.Tab') ...
+                    && exist('uim.utility.getContentPixelPosition', 'file') == 2
+                position = uim.utility.getContentPixelPosition(parent);
+            elseif isprop(parent, 'Position')
+                position = [0, 0, parent.Position(3:4)];
+            else
+                position = getpixelposition(parent);
+                position(1:2) = [0, 0];
+            end
+            position(3:4) = max(1, position(3:4));
+        end
+
+        function setComponentPixelPosition(~, hComponent, position)
+            if isprop(hComponent, 'Units')
+                setpixelposition(hComponent, position)
+            else
+                hComponent.Position = position;
+            end
         end
 
         function initializeFileViewer(app, hTab)
@@ -1512,7 +1537,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                 str = '';
             end
 
-            set(app.UiMetaTableViewer.HTable.JTable, 'ToolTipText', str)
+            app.UiMetaTableViewer.setTableTooltip(str)
         end
     
         function onAvailableDisksChanged(app)
@@ -1792,8 +1817,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                 app.UiMetaTableViewer.refreshTable(app.MetaTable)
                 app.UiMetaTableViewer.setSelectedEntries(selectedEntries);
             else
-                newValue = nansen.metadata.utility.formatTableForDisplay(...
-                    app.MetaTable, evt.ColumnIndex, evt.RowIndex);
+                newValue = app.MetaTable.getFormattedTableData(...
+                    evt.ColumnIndex, evt.RowIndex, app.getMetaTableDisplayContext());
                 newValue = table2cell(newValue);
 
                 app.UiMetaTableViewer.updateCells(...
@@ -2564,7 +2589,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                 % effect of having decided to set metatable of
                 % metatableviewer to type table...
                 columnIndex = app.MetaTable.getColumnIndex(variableName);
-                columnData = nansen.metadata.utility.formatTableForDisplay(app.MetaTable, columnIndex);
+                columnData = app.MetaTable.getFormattedTableData(...
+                    columnIndex, [], app.getMetaTableDisplayContext());
                 app.UiMetaTableViewer.updateFormattedTableColumnData(variableName, columnData)
 
                 app.UiMetaTableViewer.refreshColumnModel();
@@ -3361,13 +3387,16 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         
         function onNewMetaTableSet(app)
             if isempty(app.UiMetaTableViewer);    return;    end
-            app.UiMetaTableViewer.refreshColumnModel()
+            refreshCleanup = app.UiMetaTableViewer.suspendRefresh();
+            app.UiMetaTableViewer.refreshColumnModel(false)
             if ~strcmpi(app.UiMetaTableViewer.MetaTableType, app.MetaTable.getTableType())
                 % If table type is changed, use the flush option.
                 app.UiMetaTableViewer.refreshTable(app.MetaTable, true)
             else
                 app.UiMetaTableViewer.refreshTable(app.MetaTable)
             end
+            delete(refreshCleanup)
+            app.updateMetaTableViewerPosition()
             app.updateTableItemCount()
         end
         
@@ -4251,6 +4280,9 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         
         function saveMetatableColumnSettingsToProject(app)
             if isempty(app.UiMetaTableViewer); return; end
+            if ismethod(app.UiMetaTableViewer, 'flushColumnSettings')
+                app.UiMetaTableViewer.flushColumnSettings()
+            end
             columnSettings = app.UiMetaTableViewer.ColumnSettings;
             currentProjectName = app.ProjectManager.CurrentProject;
             projectObj = app.ProjectManager.getProjectObject(currentProjectName);
@@ -4264,6 +4296,13 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             projectObj = app.ProjectManager.getProjectObject(currentProjectName);
 
             columnSettings = projectObj.loadData('MetatableColumnSettings', "LoadFromJson", true);
+        end
+
+        function displayContext = getMetaTableDisplayContext(app)
+            displayContext = 'legacy';
+            if ~isempty(app.UiMetaTableViewer) && app.UiMetaTableViewer.usesModernBackend()
+                displayContext = 'modern';
+            end
         end
     end
 

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -1337,11 +1337,15 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             if isa(parent, 'matlab.ui.container.Tab') ...
                     && exist('uim.utility.getContentPixelPosition', 'file') == 2
                 position = uim.utility.getContentPixelPosition(parent);
-            elseif isprop(parent, 'Position')
-                position = [0, 0, parent.Position(3:4)];
             else
-                position = getpixelposition(parent);
-                position(1:2) = [0, 0];
+                try
+                    % MATLAB R2024 tab Position can be normalized [0 0 1 1].
+                    % Use pixel geometry so legacy Java tables are not collapsed.
+                    position = getpixelposition(parent);
+                    position(1:2) = [0, 0];
+                catch
+                    position = [0, 0, parent.Position(3:4)];
+                end
             end
             position(3:4) = max(1, position(3:4));
         end

--- a/code/apps/+nansen/@FileViewer/FileViewer.m
+++ b/code/apps/+nansen/@FileViewer/FileViewer.m
@@ -240,7 +240,7 @@ classdef FileViewer < nansen.AbstractTabPageModule
             M = 0; % Margin
 
             if ~isempty(obj.hStatusLabel)
-                parentPosition = getpixelposition(obj.Parent);
+                parentPosition = uim.utility.getContentPixelPosition(obj.Parent);
                 centerPosition = parentPosition(1:2) + parentPosition(3:4) / 2;
                 if obj.UseModernUi
                     newPosition = obj.hStatusLabel(1).Position;
@@ -258,15 +258,16 @@ classdef FileViewer < nansen.AbstractTabPageModule
                 end
             end
 
-            parentPosition = getpixelposition(obj.TabGroup.SelectedTab);
+            parentPosition = uim.utility.getContentPixelPosition(obj.TabGroup.SelectedTab);
 
-            [X, W] = subdividePosition(M, parentPosition(3), [200, 1]);
+            [X, W] = subdividePosition(parentPosition(1)-1, parentPosition(3), [200, 1]);
             H = parentPosition(4);
+            Y = parentPosition(2);
             
             if ~isempty(obj.SessionListBox)
                 if obj.UseModernUi
                     for i = 1:numel(obj.SessionListBox)
-                        obj.SessionListBox(i).Position = [X(1), 1, W(1), H];
+                        obj.SessionListBox(i).Position = [X(1), Y, W(1), H];
                     end
                 else
                     arrayfun(@(h)setpixelposition(h, [X(1), 1, W(1), H]), obj.SessionListBox)
@@ -276,7 +277,7 @@ classdef FileViewer < nansen.AbstractTabPageModule
                 if obj.UseModernUi
                     treeList = struct2cell(obj.hFolderTree);
                     for i = 1:numel(treeList)
-                        treeList{i}.Position = [X(2), 0, W(2)+1, H+2];
+                        treeList{i}.Position = [X(2), Y, W(2), H];
                     end
                 else
                     structfun(@(h) setpixelposition(h, [X(2), 0, W(2)+1, H+2]), obj.hFolderTree);

--- a/code/apps/+nansen/@MessageDisplay/MessageDisplay.m
+++ b/code/apps/+nansen/@MessageDisplay/MessageDisplay.m
@@ -94,12 +94,17 @@ classdef MessageDisplay < handle
         end
 
         function formattedMessage = getFormattedMessage(obj, message)
-            % Prepend specifier with fontsize
-            formatSpec = sprintf('\\fontsize{%d}', obj.FontSize);
-            formattedMessage = strcat(formatSpec, message);
-            
-            % Fix some characters that are interpreted as tex markup
-            formattedMessage = strrep(formattedMessage, '_', '\_');
+            if nansen.util.isJavaFrameSupported()
+                % For javaframe backed figures, the fontsize of modal
+                % dialogs is small, so we increase it via text formatting.
+                formatSpec = sprintf('\\fontsize{%d}', obj.FontSize);
+                formattedMessage = strcat(formatSpec, message);
+                
+                % Fix some characters that are interpreted as tex markup
+                formattedMessage = strrep(formattedMessage, '_', '\_');
+            else
+                formattedMessage = message;
+            end
         end
     end
 end

--- a/code/apps/+nansen/@MetaTableViewer/MetaTableViewer.m
+++ b/code/apps/+nansen/@MetaTableViewer/MetaTableViewer.m
@@ -1,1652 +1,338 @@
-classdef MetaTableViewer < handle & uiw.mixin.AssignPVPairs
-%MetaTableViewer Implementation of UI table for viewing metadata tables.
+classdef MetaTableViewer < handle
+%MetaTableViewer Public facade for metadata table viewers.
 %
-%   This class is built around the Table class from the Widgets Toolbox.
-%   This is a very responsive java based table implementation. This class
-%   extends the functionality of the uiw.widget.Table in primarily two
-%   ways:
-%       1) Columns can be filtered
-%       2) Settings for columns are saved until next time table is opened.
-%           (Columns widths, column visibility and column label is saved
-%           across matlab sessions) Todo: Also save column editable...
-    
-% - - - - - - - - - - - - - - - TODO - - - - - - - - - - - - - - - - -
-    %  *[ ] Update table without emptying data! Use add column/remove
-    %   [ ] jTable.setPreserveSelectionsAfterSorting(true); Is this useful
-    %       here???
-    %   [ ] Save table settings to project folder
-
-    %       column from the java column model when hiding/showing columns
-    %   [ ] Outsource everything column related to column model
-    %   [ ] Create table with all columns and store the tablecolumn objects in the column model if rows are hidden?
-    %
-    %   [x] Make ignore column editable
-    %   [x] Set method for metaTable...
-    %   [x] Revert change from metatable. need to get formatted data from
-    %       table!
-    %   [ ] Should the filter be a RowModel?
-    %   [ ] Make method for getting colorcoded column names (based on
-    %   column filters, and always run columnNames through this method
-    %   before setting the on the table object
-    %   [ ] Will ColumnFilter.isColumnFilterActive always match the columns
-    %       in the column model? Need to verify
-    %   [ ] Straighten out what to do about the MetaTable property.
-    %       Problem: if the input metatable was a MetaTable object, it
-    %       might contain data which is not renderable in the uitable, i.e
-    %       structs. If table data is changed, and data is put back into
-    %       the table version of the MetaTable, the set.MetaTable methods
-    %       creates a downstream bug because it sets it, and consequently
-    %       the MetaTableCell property without getting formatted data from
-    %       the metatable class. For now, I keep as it is, because the only
-    %       column I edit is the ignore column, and the MetaTable property
-    %       is not used anywhere. But this can be a BIG PROBLEM if things
-    %       change some time.
-    
-% - - - - - - - - - - - - - - PROPERTIES - - - - - - - - - - - - - - -
+%   This class preserves the historical nansen.MetaTableViewer API while
+%   delegating rendering and interaction to a release-specific backend. The
+%   legacy backend keeps the Java/Widgets Toolbox implementation for older
+%   MATLAB releases. MATLAB R2025a and newer use a native uitable backend.
 
     properties (Constant, Hidden)
         VALID_TABLE_CLASS = {'nansen.metadata.MetaTable', 'table'};
     end
-    
-    properties % Table preferences
-        ShowIgnoredEntries = true
-        AllowTableEdits = true
-        TableFontSize = 12
-        MetaTableType = 'session' %Note: should always be lowercase
-    end
 
-    properties
-        SelectedEntries         % Selected rows from full table, irrespective of sorting and filtering.
-        CellEditCallback
-        KeyPressCallback
-        
-        MouseDoubleClickedFcn = [] % This should be internalized, but for now it is assigned from session browser/nansen
-        
-        DeleteColumnFcn = []    % This should be internalized, but for now it is assigned from session browser/nansen
-        UpdateColumnFcn = []    % This should be internalized, but for now it is assigned from session browser/nansen
-        ResetColumnFcn = []     % This should be internalized, but for now it is assigned from session browser/nansen
-        EditColumnFcn = []      % This should be internalized, but for now it is assigned from session browser/nansen
-    
-        % Does this make sense? Thinking that this should be taken care of
-        % at another level, as the Metatable viewer is not nansen specific...
-        GetTableVariableAttributesFcn = [] % Function handle for retrieving table variable attributes.
-    end
-    
-    properties (SetAccess = private, SetObservable = true)
-        MetaTable               % Table version of the table data
-        MetaTableCell cell      % Cell array version of the table data
-        MetaTableVariableNames  % Cell array of variable names in full table
-        MetaTableVariableAttributes % Struct with attributes of metatable variables.
+    properties (Access = private)
+        Backend
+        SelectionChangedListener event.listener
+        TableUpdatedListener event.listener
     end
 
     properties (Dependent)
+        ShowIgnoredEntries
+        AllowTableEdits
+        TableFontSize
+        MetaTableType
+
+        SelectedEntries
+        CellEditCallback
+        KeyPressCallback
+        MouseDoubleClickedFcn
+        DeleteColumnFcn
+        UpdateColumnFcn
+        ResetColumnFcn
+        EditColumnFcn
+        GetTableVariableAttributesFcn
+
         ColumnSettings
 
-        % DisplayedRows - Rows of the original metatable which are
-        % currently displayed
-        DisplayedRows
-        
-        % DisplayedColumns - Columns of the original metatable which are
-        % currently displayed (not implemented yet)
-        % DisplayedColumns
-    end
-    
-    properties (SetAccess = private)
-        ColumnModel             % Class instance for updating columns based on user preferences.
-        ColumnFilter            % Class instance for filtering data based on column variables.
-    end
-    
-    properties %(Access = private)
-        
         AppRef
         Parent
+        ColumnContextMenu
+        TableContextMenu
+        DataFilterMap
+        ExternalFilterMap
+    end
+
+    properties (Dependent, SetAccess = private)
+        MetaTable
+        MetaTableCell
+        MetaTableVariableNames
+        MetaTableVariableAttributes
+        DisplayedRows
+
+        ColumnModel
+        ColumnFilter
+
         HTable
         JTable
-        
-        ColumnContextMenu = []
-        TableContextMenu = []
-        
-        DataFilterMap = []  % Boolean "map" (numRows x numColumns) with false for cells that is outside filter range
-        ExternalFilterMap = [] % Boolean vector with rows that are "filtered" externally. Todo: Formalize this better.
-        FilterChangedListener event.listener
-        
-        ColumnWidthChangedListener
-        ColumnsRearrangedListener
-        MouseDraggedInHeaderListener
-        
-        ColumnPressedTimer
     end
-    
-    properties (Access = private)
-        ColumnSettings_
-        lastMousePressTic
-        IsConstructed = false;
-        RequireReset = false;
-    end
-    
+
     events
         TableUpdated
         SelectionChanged
     end
-    
-% - - - - - - - - - - - - - - - METHODS - - - - - - - - - - - - - - -
-    
-    methods % Structors
-        
+
+    methods
         function obj = MetaTableViewer(varargin)
-        %MetaTableViewer Construct for MetaTableViewer
-        
-            % Take care of input arguments.
-            obj.parseInputs(varargin)
-
-            %if ~isempty(obj.ColumnSettings)
-                nvPairs = {'ColumnSettings', obj.ColumnSettings};
-            %else
-            %    nvPairs = {};
-            %end
-            
-            % Initialize the column model.
-            obj.ColumnModel = nansen.ui.MetaTableColumnLayout(obj, nvPairs{:});
-            
-            obj.createUiTable()
-            
-            obj.ColumnFilter = nansen.ui.MetaTableColumnFilter(obj, obj.AppRef);
-            
-            obj.IsConstructed = true;
-
-            if ~isempty(obj.MetaTableCell)
-                obj.refreshTable()
-                obj.HTable.Visible = 'on'; % Make table visible
-                drawnow
+            if nansen.util.useModernUiTable()
+                obj.Backend = nansen.ui.metatable.EntityTableMetaTableViewer(varargin{:});
+            else
+                obj.Backend = nansen.ui.metatable.LegacyJavaMetaTableViewer(varargin{:});
             end
+
+            obj.SelectionChangedListener = addlistener(obj.Backend, ...
+                'SelectionChanged', @(src, evt) obj.notifySelectionChanged(evt));
+            obj.TableUpdatedListener = addlistener(obj.Backend, ...
+                'TableUpdated', @(src, evt) obj.notifyTableUpdated(evt));
         end
-       
+
         function delete(obj)
-            if ~isempty(obj.HTable) && isvalid(obj.HTable)
-                columnWidths = obj.HTable.ColumnWidth;
-                if ~isempty(columnWidths)
-                    obj.ColumnModel.setColumnWidths(columnWidths);
-                end
-
-                delete(obj.ColumnModel)
-                delete(obj.HTable)
+            if ~isempty(obj.SelectionChangedListener)
+                delete(obj.SelectionChangedListener)
+            end
+            if ~isempty(obj.TableUpdatedListener)
+                delete(obj.TableUpdatedListener)
+            end
+            if ~isempty(obj.Backend) && isvalid(obj.Backend)
+                delete(obj.Backend)
             end
         end
     end
-    
-    methods % Set/get
-        
-        function rowIndices = get.DisplayedRows(obj)
-            if ~isempty(obj.ExternalFilterMap)
-                visibleRows = find( obj.ExternalFilterMap );
+
+    methods
+        function refreshColumnModel(obj, varargin)
+            obj.Backend.refreshColumnModel(varargin{:})
+        end
+
+        function cleanup = suspendRefresh(obj)
+            cleanup = onCleanup(@() []);
+            if ismethod(obj.Backend, 'suspendRefresh')
+                cleanup = obj.Backend.suspendRefresh();
+            end
+        end
+
+        function setBusy(obj, isBusy, message)
+            arguments
+                obj
+                isBusy (1,1) logical
+                message (1,1) string = "Working..."
+            end
+
+            if ismethod(obj.Backend, 'setBusy')
+                obj.Backend.setBusy(isBusy, message)
+            end
+        end
+
+        function resetTable(obj, varargin)
+            obj.Backend.resetTable(varargin{:})
+        end
+
+        function resetColumnFilters(obj, varargin)
+            obj.Backend.resetColumnFilters(varargin{:})
+        end
+
+        function updateCells(obj, varargin)
+            obj.Backend.updateCells(varargin{:})
+        end
+
+        function updateTableRow(obj, varargin)
+            obj.Backend.updateTableRow(varargin{:})
+        end
+
+        function updateFormattedTableColumnData(obj, varargin)
+            obj.Backend.updateFormattedTableColumnData(varargin{:})
+        end
+
+        function updateVisibleRows(obj, varargin)
+            obj.Backend.updateVisibleRows(varargin{:})
+        end
+
+        function refreshTable(obj, varargin)
+            obj.Backend.refreshTable(varargin{:})
+        end
+
+        function replaceTable(obj, varargin)
+            obj.Backend.replaceTable(varargin{:})
+        end
+
+        function rowInd = getMetaTableRows(obj, varargin)
+            rowInd = obj.Backend.getMetaTableRows(varargin{:});
+        end
+
+        function IND = getSelectedEntries(obj, varargin)
+            IND = obj.Backend.getSelectedEntries(varargin{:});
+        end
+
+        function setSelectedEntries(obj, varargin)
+            obj.Backend.setSelectedEntries(varargin{:})
+        end
+
+        function [columnNames, variableNames] = getColumnNames(obj, varargin)
+            [columnNames, variableNames] = obj.Backend.getColumnNames(varargin{:});
+        end
+
+        function focusTable(obj)
+            if ismethod(obj.Backend, 'focusTable')
+                obj.Backend.focusTable()
+            elseif ~isempty(obj.JTable)
+                obj.JTable.requestFocus()
+            end
+        end
+
+        function setTableTooltip(obj, tooltipText)
+            if ismethod(obj.Backend, 'setTableTooltip')
+                obj.Backend.setTableTooltip(tooltipText)
+            elseif ~isempty(obj.JTable)
+                set(obj.JTable, 'ToolTipText', tooltipText)
+            end
+        end
+
+        function setKeyPressFcn(obj, callback)
+            if ismethod(obj.Backend, 'setKeyPressFcn')
+                obj.Backend.setKeyPressFcn(callback)
+            elseif ~isempty(obj.HTable)
+                obj.HTable.KeyPressFcn = callback;
+            end
+        end
+
+        function listenerHandle = addMouseMotionCallback(obj, callback)
+            listenerHandle = [];
+            if ismethod(obj.Backend, 'addMouseMotionCallback')
+                listenerHandle = obj.Backend.addMouseMotionCallback(callback);
+            elseif ~isempty(obj.HTable)
+                listenerHandle = addlistener(obj.HTable, 'MouseMotion', callback);
+            end
+        end
+
+        function n = getDisplayedRowCount(obj)
+            if ismethod(obj.Backend, 'getDisplayedRowCount')
+                n = obj.Backend.getDisplayedRowCount();
+            elseif ~isempty(obj.HTable)
+                n = size(obj.HTable.Data, 1);
             else
-                visibleRows = 1:size(obj.MetaTableCell, 1);
+                n = 0;
             end
-            
-            rowIndices = obj.getCurrentRowSelection();
-            rowIndices = intersect(rowIndices, visibleRows, 'stable');
         end
 
-        function set.MetaTable(obj, newTable)
-        % Set method for metatable.
-        %
-        % 1) If the newValue is a MetaTable object, the table data is
-        %    retrieved before updating the property.
-        % 2) After new value is set it is passed on the onMetaTableSet
-        %    method which will also update the metaTableCell property and
-        %    update the ui table.
-        
-            if isa(newTable, 'nansen.metadata.MetaTable')
-                obj.MetaTable = newTable.entries;
-            elseif isa(newTable, 'table')
-                obj.MetaTable = newTable;
+        function n = getSelectedRowCount(obj)
+            if ismethod(obj.Backend, 'getSelectedRowCount')
+                n = obj.Backend.getSelectedRowCount();
+            elseif ~isempty(obj.HTable)
+                n = numel(obj.HTable.SelectedRows);
             else
-                error('New value of MetaTable property must be a MetaTable or a table object')
-            end
-            
-            obj.onMetaTableSet(newTable)
-        end
-       
-        function set.MetaTableType(obj, newValue)
-            oldType = obj.MetaTableType;
-            obj.MetaTableType = lower(newValue);
-            obj.onMetaTableTypeSet(oldType, lower(newValue))
-        end
-
-        function set.ColumnSettings(obj, newSettings)
-            if isempty(obj.ColumnModel)
-                obj.ColumnSettings_ = newSettings;
-            else
-                obj.ColumnModel.replaceColumnSettings(newSettings);
-                obj.updateColumnLayout()
-            end
-        end
-        function colSettings = get.ColumnSettings(obj)
-            if isempty(obj.ColumnModel)
-                colSettings = obj.ColumnSettings_;
-            else
-                colSettings = obj.ColumnModel.settings;
+                n = 0;
             end
         end
 
-        function set.ColumnFilter(obj, newValue)
-            obj.ColumnFilter = newValue;
-            if ~isempty(newValue)
-                obj.onColumnFilterSet()
-            end
-        end
-            
-        function set.ShowIgnoredEntries(obj, newValue)
-            
-            assert(islogical(newValue), 'Value for ShowIgnoredEntries must be a boolean')
-            obj.ShowIgnoredEntries = newValue;
-            
-            obj.refreshTable()
-        end
-        
-        function set.AllowTableEdits(obj, newValue)
-            
-            assert(islogical(newValue), 'Value for AllowTableEdits must be a boolean')
-            obj.AllowTableEdits = newValue;
-                      
-            obj.updateColumnEditable()
-        end
-        
-        function set.TableFontSize(obj, newValue)
-            obj.TableFontSize = newValue;
-            obj.onTableFontSizeSet()
+        function tf = usesModernBackend(obj)
+            tf = isa(obj.Backend, 'nansen.ui.metatable.EntityTableMetaTableViewer') || ...
+                isa(obj.Backend, 'nansen.ui.metatable.ModernUiMetaTableViewer');
         end
 
-        function set.KeyPressCallback(obj, newValue)
-            
+        function fitColumnsToTableWidth(obj)
+            if ismethod(obj.Backend, 'fitColumnsToTableWidth')
+                obj.Backend.fitColumnsToTableWidth()
+            end
         end
 
-        function set.GetTableVariableAttributesFcn(obj, newValue)
-            obj.GetTableVariableAttributesFcn = newValue;
-            obj.onTableVariableAttributesFcnSet()
-        end
-    end
-        
-    methods % Public methods
-        
-        function refreshColumnModel(obj)
-        %refreshColumnModel Refresh the columnmodel
-        %
-        %   Note: This method should be called whenever a new metatable is
-        %   set, and whenever a metatable variable definition is changed.
-        %
-        %   Todo: {Find a way to make this happen when it is needed, instead
-        %   of requiring this method to be called explicitly. This fix need
-        %   to be implemented on the class (table model) owning the
-        %   columnmodel}
-            
-            obj.ColumnModel.updateColumnEditableState()
-        end
-        
-        function resetTable(obj, resetView)
-            
-            % Note: There is an option here to not reset the table view,
-            % This is useful for aethetic reasons, to prevent flickering
-            % when updating a table.
-            if nargin < 2
-                resetView = true; % todo: make nv pair args
-            end
-
-            obj.MetaTable = table.empty;
-            
-            if resetView
-                obj.refreshTable(table.empty, true)
-            end
-        end
-        
-        function resetColumnFilters(obj)
-            obj.ColumnFilter.resetFilters()
-        end
-                
-        function updateCells(obj, rowIdxData, colIdxData, newData)
-        %updateCells Update subset of cells...
-        
-            % Note: The uiw.widget.Table setCell method takes the java
-            % table model's row order into account when inserting data into
-            % cells, but not the column order. That's why the rearrangement
-            % of rows and columns below are not equivalent
-            
-            % Place new data in the cell representation of the metatable.
-            obj.MetaTableCell(rowIdxData, colIdxData) = newData;
-            
-            % Get indices of visible rows based on data filter states
-            rowIdxVisible = obj.getCurrentRowSelection();
-            
-            % Get indices of visible columns based on user selection of which columns to display
-            colIdxVisible = obj.getCurrentColumnSelection();
-            
-            % Rearrange rows taking the table sorting into account:
-            if ~isempty(obj.HTable.RowSortIndex)
-                rowIdxVisible = rowIdxVisible(obj.HTable.RowSortIndex);
-            end
-
-            % Get the current order of column indices from java's column model
-            [colIdxJava, ~] = obj.ColumnModel.getColumnModelIndexOrder();
-            
-            %Todo: Is it still a possibility that these are not the same length?
-            %colIdxVisible = colIdxVisible(colIdxJava);
-                        
-            % Get the indices for where to insert data in the uitable, i.e
-            % find which index of the visible data that corresponds with
-            % the index of the actual data.
-            [~, rowIdxUiTable, rowIdxDataSubset] = intersect(rowIdxVisible, rowIdxData, 'stable');
-            [~, colIdxUiTable, colIdxDataSubset] = intersect(colIdxVisible, colIdxData, 'stable');
-            
-            % Insert data into the table model cell by cell
-            for i = 1:numel(rowIdxUiTable)
-                for j = 1:numel(colIdxUiTable)
-                    % Get indices for current uitable cell
-                    iRow = rowIdxUiTable(i);
-                    jCol = colIdxJava( colIdxUiTable(j) ); % Reorder based on the underlying column order of the java model because this is not done internally in setCell
-                    % Get value of data for current cell
-                    thisValue = newData(rowIdxDataSubset(i), colIdxDataSubset(j));
-                    % Insert value
-                    obj.HTable.setCell(iRow, jCol, thisValue)
-                end
-            end
-            drawnow
-        end
-
-        function updateTableRow(obj, rowIdxData, tableRowData)
-        %updateTableRow Update data of specified table row
-            % Count number of columns and get column indices
-            colIdx = 1:size(tableRowData, 2);
-            
-            if isa(tableRowData, 'table')
-                newData = table2cell(tableRowData);
-            elseif isa(tableRowData, 'cell')
-                %pass
-            else
-                error('Table row data is in the wrong format')
-            end
-            
-            % Refresh cells of ui table...
-            obj.updateCells(rowIdxData, colIdx, newData)
-        end
-
-        function updateFormattedTableColumnData(obj, columnName, columnData)
-        %reformatTableColumnData Reformat data for specified column
-            columnIndex = find(strcmp(obj.MetaTable.Properties.VariableNames, columnName));
-            obj.MetaTableCell(:, columnIndex) = table2cell(columnData);
-        end
-
-        function appendTableRow(obj, rowData)
-            % Would be neat, but haven't found a way to do it.
-        end
-        
-        function updateVisibleRows(obj, rowInd)
-
-            [numRows, ~] = size(obj.MetaTable);
-            obj.ExternalFilterMap = false(numRows, 1);
-            obj.ExternalFilterMap(rowInd) = true;
-                        
-            obj.updateTableView(rowInd)
-        end
-        
-        function refreshTable(obj, newTable, flushTable)
-        %refreshTable Method for refreshing the table
-        
-            % TODO: Make sure the selection is maintained.
-            
-            % Note: If [] is provided as 2nd arg, the table is not reset.
-            % This might be used in some cases where the table should be
-            % kept, but the flushTable flag is provided.
-            
-            requireReset = isempty( obj.MetaTable ) || obj.RequireReset;
-
-            if nargin >= 2 && ~(isnumeric(newTable) && isempty(newTable))
-                obj.MetaTable = newTable;
-            end
-            
-            if nargin < 3 || isempty(flushTable)
-                flushTable = requireReset;
-            end
-            
-            % Todo: Save selection
-            %selectedEntries = obj.getSelectedEntries();
-
-            if flushTable % Empty table, gives smoother update in some cases
-                obj.HTable.Data = {};
-                obj.DataFilterMap = []; % reset data filter map
-                if ~isempty(obj.MetaTable)
-                    obj.ColumnFilter.onMetaTableChanged()
-                end
-                obj.RequireReset = false;
-            else
-                if ~isempty(obj.ColumnFilter)
-                    obj.ColumnFilter.onMetaTableUpdated()
-                end
-            end
-            
-            drawnow
-            if ~isempty(obj.MetaTable)
-                obj.updateMetaTableVariableAttributes()
-                obj.updateColumnLayout()
-                obj.updateTableView()
-            else
-                obj.HTable.ColumnName = cell(1,0);
-            end
-            drawnow
-            % Todo: Restore selection
-            %obj.setSelectedEntries(selectedEntries);
-        end
-        
-        function replaceTable(obj, newTable)
-            obj.MetaTable = newTable;
-            obj.ColumnFilter.onMetaTableChanged()
-            obj.updateTableView()
-        end
-        
-        function rowInd = getMetaTableRows(obj, rowIndDisplay)
-            
-            % Todo: Determine if this method is useful in
-            % getSelectedEntries/setSelectedEntries?
-            dataInd = get(obj.HTable.JTable.Model, 'Indexes');
-            
-            if ~isempty(dataInd)
-                rowInd = dataInd(rowIndDisplay)+1; % +1 because java indices start at 0
-            else
-                rowInd = rowIndDisplay;
-            end
-      
-            % Get currently visible row and column indices.
-            visibleRowInd = obj.getCurrentRowSelection();
-            
-            % Get row and column indices for original data (unfiltered, unsorted, allcolumns)
-            rowInd = visibleRowInd(rowInd);
-            
-            % Make sure output is a column vector
-            if iscolumn(rowInd)
-                rowInd = transpose(rowInd);
-            end
-        end
-        
-        function IND = getSelectedEntries(obj)
-        %getSelectedEntries Get selected entries based on the MetaTable
-        %
-        %   Get selected entry from original metatable taking column
-        %   sorting and filtering into account.
-        
-            IND = obj.HTable.SelectedRows;
-            
-            dataInd = get(obj.HTable.JTable.Model, 'Indexes');
-
-            if ~isempty(dataInd)
-                IND = dataInd(IND)+1; % +1 because java indices start at 0
-                IND = transpose( double( sort(IND) ) ); % return as row vector
-            else
-                IND = IND;
-            end
-            
-            % Get currently visible row and column indices.
-            visibleRowInd = obj.getCurrentRowSelection();
-            
-            % Get row and column indices for original data (unfiltered, unsorted, allcolumns)
-            IND = visibleRowInd(IND);
-        end
-       
-        function setSelectedEntries(obj, IND, preventCallback)
-        %setSelectedEntries Set row selection
-        
-            if nargin < 3
-                preventCallback = false; % todo: make nv pair args
-            end
-
-            % Get currently visible row indices.
-            visibleRowInd = obj.getCurrentRowSelection();
-            
-            % Get row indices based on the underlying table model (taking sorting into account)
-            dataInd = get(obj.HTable.JTable.Model, 'Indexes') + 1;
-            if isempty(dataInd)
-                dataInd = 1:numel(visibleRowInd);
-            end
-            
-            % Reorder the visible row indices according to possible sort
-            % order
-            visibleRowInd = visibleRowInd(dataInd);
-            
-            % Find the rownumber corresponding to the given entries.
-            selectedRows = find(ismember(visibleRowInd, IND));
-
-            % Set the row selection
-            if preventCallback
-                obj.HTable.disableCallbacks();
-                obj.HTable.SelectedRows = selectedRows;
-                drawnow
-                obj.HTable.enableCallbacks();
-            else
-                obj.HTable.SelectedRows = selectedRows;
-            end
-        end
-    
-        function [columnNames,variableNames] = getColumnNames(obj, columnIndices)
-        % getColumnNames - Get name of column(s) given column indices
-            if nargin < 2; columnIndices = []; end
-            
-            [columnNames,variableNames] = obj.ColumnModel.getColumnNames();
-            if ~isempty(columnIndices)
-                columnNames = columnNames(columnIndices);
-                variableNames = variableNames(columnIndices);
-            end
-            if numel(columnNames) == 1 && iscell(columnNames)
-                columnNames = columnNames{1};
-                variableNames = variableNames{1};
+        function flushColumnSettings(obj)
+            if ismethod(obj.Backend, 'flushColumnSettings')
+                obj.Backend.flushColumnSettings()
             end
         end
     end
-   
-    methods (Access = private) % Create components
-        
-        function parseInputs(obj, listOfArgs)
-         %parseInputs Input parser that checks for expected input classes
-            
-            [nvPairs, remainingArgs] = utility.getnvpairs(listOfArgs);
-            
-            % Need to set name value pairs first
-            obj.assignPVPairs(nvPairs{:})
-            
-            if isempty(remainingArgs);    return;    end
-            
-            % Check if first argument is a graphical container
-            % Todo: check that graphical object is an actual container...
-            if isgraphics(remainingArgs{1})
-                obj.Parent = remainingArgs{1};
-                remainingArgs = remainingArgs(2:end);
-            end
-            
-            if isempty(remainingArgs);    return;    end
 
-            % Check if first argument in list is a valid metatable class
-            if obj.isValidTableClass( remainingArgs{1} )
-                obj.MetaTable = remainingArgs{1};
-                remainingArgs = remainingArgs(2:end);
-            end
-            
-            if isempty(remainingArgs);    return;    end
+    methods
+        function value = get.ShowIgnoredEntries(obj), value = obj.Backend.ShowIgnoredEntries; end
+        function set.ShowIgnoredEntries(obj, value), obj.Backend.ShowIgnoredEntries = value; end
 
-        end
-        
-        function createUiTable(obj)
-            
-            for i = 1:2
-            
-                try
-                    obj.HTable = uim.widget.StylableTable(...
-                        'Parent', obj.Parent,...
-                        'Tag','MetaTable',...
-                        'Editable', true, ...
-                        'RowHeight', 30, ...
-                        'FontSize', obj.TableFontSize, ...
-                        'FontName', 'helvetica', ...
-                        'FontName', 'avenir next', ...
-                        'SelectionMode', 'discontiguous', ...
-                        'Sortable', true, ...
-                        'Units','normalized', ...
-                        'Position',[0 0.0 1 1], ...
-                        'HeaderPressedCallback', @obj.onMousePressedInHeader, ...
-                        'HeaderReleasedCallback', @obj.onMouseReleasedFromHeader, ...
-                        'MouseClickedCallback', @obj.onMousePressedInTable, ...
-                        'Visible', 'off', ...
-                        'BackgroundColor', [1,1,0.5]);
-                    break
-                
-                catch ME
-                    switch ME.identifier
-                        case 'MATLAB:Java:ClassLoad'
-                            nansen.internal.setup.addUiwidgetsJarToJavaClassPath()
-                        otherwise
-                            rethrow(ME)
-                    end
-                end
-            end
-            
-            if isempty(obj.HTable)
-                tf = nansen.internal.setup.isUiwidgetsOnJavapath();
-                if ~tf
-                    error('Failed to create the gui. Try to install to Widgets Toolbox v1.3.330 again')
-                else
-                    error('Nansen:MetaTableViewer:CorruptedJavaPath', ...
-                        'uiwidget jar is on javapath, but table creation failed.')
-                end
-            end
-            
-            obj.HTable.CellEditCallback = @obj.onCellValueEdited;
-            obj.HTable.CellSelectionCallback = @obj.onCellSelectionChanged;
-            obj.HTable.JTable.getTableHeader().setReorderingAllowed(true);
-            obj.JTable = obj.HTable.JTable;
+        function value = get.AllowTableEdits(obj), value = obj.Backend.AllowTableEdits; end
+        function set.AllowTableEdits(obj, value), obj.Backend.AllowTableEdits = value; end
 
-            % Listener that detects if column widths change if user drags
-            % column headers edges to resize columns.
-            obj.ColumnWidthChangedListener = listener(obj.HTable, ...
-                'ColumnWidthChanged', @obj.onColumnWidthChanged);
-            
-            obj.ColumnsRearrangedListener = listener(obj.HTable, ...
-                'ColumnsRearranged', @obj.onColumnsRearranged);
-            
-            obj.MouseDraggedInHeaderListener = listener(obj.HTable, ...
-                'MouseDraggedInHeader', @obj.onMouseDraggedInTableHeader);
-            
-            obj.HTable.Theme = uim.style.tableLight;
-            
-        end
-        
-        function createColumnContextMenu(obj)
-        %createColumnContextMenu Create a context menu for columns
-        
-        % Note: This context menu is reused for all columns, but because
-        % it's appearance might depend on the column it is opened above,
-        % some changes are done in the method openColumnContextMenu before
-        % it is made visible. Also, a callback function is set there.
-        
-            hFigure = ancestor(obj.Parent, 'figure');
-            
-            % Create a context menu item for each of the different column
-            % formats.
+        function value = get.TableFontSize(obj), value = obj.Backend.TableFontSize; end
+        function set.TableFontSize(obj, value), obj.Backend.TableFontSize = value; end
 
-            obj.ColumnContextMenu = uicontextmenu(hFigure);
-            
-            % Create items of the menu for columns of char type
-            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Sort A-Z');
-            hTmp.Tag = 'Sort Ascend';
-            
-            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Sort Z-A');
-            hTmp.Tag = 'Sort Descend';
-            
-% %             hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Filter...');
-% %             hTmp.Tag = 'Filter';
-% %             hTmp.Separator = 'on';
-            
-            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Reset Filters');
-            hTmp.Tag = 'Reset Filters';
-            hTmp.Separator = 'on';
-            
-            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Hide this column');
-            hTmp.Tag = 'Hide Column';
-            hTmp.Separator = 'on';
-            
-            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Column settings...');
-            hTmp.Tag = 'ColumnSettings';
-            hTmp.MenuSelectedFcn = @(s,e) obj.ColumnModel.editSettings;
-            
-            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Update column data');
-            hTmp.Separator = 'on';
-            hTmp.Tag = 'Update Column';
+        function value = get.MetaTableType(obj), value = obj.Backend.MetaTableType; end
+        function set.MetaTableType(obj, value), obj.Backend.MetaTableType = value; end
 
-              hSubMenu = uimenu(hTmp, 'Label', 'Update selected rows');
-              hSubMenu.Tag = 'Update selected rows';
-              hSubMenu = uimenu(hTmp, 'Label', 'Update all rows');
-              hSubMenu.Tag = 'Update all rows';
-              
-              hSubMenu = uimenu(hTmp, 'Label', 'Reset selected rows', 'Separator', 'on');
-              hSubMenu.Tag = 'Reset selected rows';
-              hSubMenu = uimenu(hTmp, 'Label', 'Reset all rows');
-              hSubMenu.Tag = 'Reset all rows';
+        function value = get.SelectedEntries(obj), value = obj.Backend.SelectedEntries; end
+        function set.SelectedEntries(obj, value), obj.Backend.SelectedEntries = value; end
 
-              hSubMenu = uimenu(hTmp, 'Label', 'Edit tablevar function', 'Separator', 'on');
-              hSubMenu.Tag = 'Edit tablevar function';
-                           
-            hTmp = uimenu(obj.ColumnContextMenu, 'Label', 'Delete this column');
-            hTmp.Tag = 'Delete Column';
-            
-        end
-        
-        function createColumnFilterComponents(obj)
-            % todo
-        end
-    end
-    
-    methods (Access = {?nansen.MetaTableViewer, ?nansen.ui.MetaTableColumnLayout, ?nansen.ui.MetaTableColumnFilter})
-          
-        function updateTableView(obj, visibleRows, requestFocus)
+        function value = get.CellEditCallback(obj), value = obj.Backend.CellEditCallback; end
+        function set.CellEditCallback(obj, value), obj.Backend.CellEditCallback = value; end
 
-            % visibleRows : list of indices of rows to show
-            % requestFocus : boolean, whether table should request focus.
+        function value = get.KeyPressCallback(obj), value = obj.Backend.KeyPressCallback; end
+        function set.KeyPressCallback(obj, value), obj.Backend.KeyPressCallback = value; end
 
-            % Note: When updating filters (especially search autocomplete)
-            % the table should not request focus. In other cases, I dont
-            % remember why the table should request focus...
+        function value = get.MouseDoubleClickedFcn(obj), value = obj.Backend.MouseDoubleClickedFcn; end
+        function set.MouseDoubleClickedFcn(obj, value), obj.Backend.MouseDoubleClickedFcn = value; end
 
-            if isempty(obj.ColumnModel); return; end % On construction...
-                        
-            [numRows, numColumns] = size(obj.MetaTableCell); %#ok<ASGLU>
+        function value = get.DeleteColumnFcn(obj), value = obj.Backend.DeleteColumnFcn; end
+        function set.DeleteColumnFcn(obj, value), obj.Backend.DeleteColumnFcn = value; end
 
-            if nargin < 2 || isempty(visibleRows); visibleRows = 1:numRows; end
-            if nargin < 3 || isempty(requestFocus); requestFocus = true; end
+        function value = get.UpdateColumnFcn(obj), value = obj.Backend.UpdateColumnFcn; end
+        function set.UpdateColumnFcn(obj, value), obj.Backend.UpdateColumnFcn = value; end
 
-            % Get based on user selection of which columns to display
-            visibleColumns = obj.getCurrentColumnSelection();
-            
-            % Get visible rows based on filter states
-            filteredRows = obj.getCurrentRowSelection();
-            visibleRows = intersect(filteredRows, visibleRows, 'stable');
+        function value = get.ResetColumnFcn(obj), value = obj.Backend.ResetColumnFcn; end
+        function set.ResetColumnFcn(obj, value), obj.Backend.ResetColumnFcn = value; end
 
-            % Get subset of data from metatable that should be put in the
-            % uitable.
-            tableDataView = obj.MetaTableCell(visibleRows, visibleColumns);
+        function value = get.EditColumnFcn(obj), value = obj.Backend.EditColumnFcn; end
+        function set.EditColumnFcn(obj, value), obj.Backend.EditColumnFcn = value; end
 
-            % Rearrange columns according to current state of the java
-            % column model
-            [javaColIndex, ~] = obj.ColumnModel.getColumnModelIndexOrder();
-            javaColIndex = javaColIndex(1:numel(visibleColumns));
-            tableDataView(:, javaColIndex) = tableDataView;
-            
-            % Assign updated table data to the uitable property
-            obj.HTable.Data = tableDataView;
-            obj.HTable.Visible = 'on';
+        function value = get.GetTableVariableAttributesFcn(obj), value = obj.Backend.GetTableVariableAttributesFcn; end
+        function set.GetTableVariableAttributesFcn(obj, value), obj.Backend.GetTableVariableAttributesFcn = value; end
 
-            obj.updateColumnLabelFilterIndicator()
-            
-            % Why????
-            if requestFocus
-                obj.HTable.JTable.requestFocus()
-            end
+        function value = get.MetaTable(obj), value = obj.Backend.MetaTable; end
 
-            drawnow
-        end
-        
-        function updateColumnLayout(obj) %protected
-        %updateColumnLayout Update the columnlayout based on user settings
-        
-            if isempty(obj.ColumnModel); return; end
-            if isempty(obj.MetaTable)
-                obj.HTable.ColumnName = {''};
-                drawnow
-                return;
-            end
-            
-            colIndices = obj.ColumnModel.getColumnIndices();
-            
-            % Set column names
-            [columnLabels, variableNames] = obj.ColumnModel.getColumnNames();
-            obj.HTable.ColumnName = columnLabels;
+        function value = get.MetaTableCell(obj), value = obj.Backend.MetaTableCell; end
+        function value = get.MetaTableVariableNames(obj), value = obj.Backend.MetaTableVariableNames; end
+        function value = get.MetaTableVariableAttributes(obj), value = obj.Backend.MetaTableVariableAttributes; end
 
-            obj.updateColumnEditable()
-            
-            % Set column widths
-            newColumnWidths = obj.ColumnModel.getColumnWidths();
-            obj.changeColumnWidths(newColumnWidths)
-            
-            C = obj.MetaTableCell; % Column format is determined from the cell version of table.
-            C = C(:, colIndices);
-            T = obj.MetaTable(1,:); % Need to check original data for special data types, i.e enums
-            T = T(:, colIndices);
-            
-            % Return if table has no rows.
-            if size(C,1)==0; return; end
-            
-            % Set column format and formatdata
-            dataTypes = cellfun(@(cell) class(cell), C(1,:), 'uni', 0);
-            colFormatData = arrayfun(@(i) [], 1:numel(dataTypes), 'uni', 0);
-            
-            dataTypes(strcmp(dataTypes, 'string')) = {'char'};
-            dataTypes(strcmp(dataTypes, 'categorical')) = {'char'};
+        function value = get.ColumnSettings(obj), value = obj.Backend.ColumnSettings; end
+        function set.ColumnSettings(obj, value), obj.Backend.ColumnSettings = value; end
 
-            % Note, this is done before checking for enum on purpose
-            % (Todo: Adapt special enum classes to also use the CompactDisplayProvider...)
-            isCustomDisplay = @(x) isa(x, 'matlab.mixin.CustomCompactDisplayProvider');
-            isCustomDisplayObj = cellfun(@(cell) isCustomDisplay(cell), table2cell(T(1,:)), 'uni', 1);
-            dataTypes(isCustomDisplayObj) = {'char'};
+        function value = get.DisplayedRows(obj), value = obj.Backend.DisplayedRows; end
 
-% % %             % Note: Important to reset this before updating. Columns can be
-% % %             % rearranged and number of columns can change. If
-% % %             % ColumnFormatData does not match the specified column format
-% % %             % an error might occur.
-% % %             obj.HTable.ColumnFormatData = colFormatData;
+        function value = get.ColumnModel(obj), value = obj.Backend.ColumnModel; end
+        function value = get.ColumnFilter(obj), value = obj.Backend.ColumnFilter; end
 
-            % Enums: (here we need to use non-cell version). Todo: Find
-            % better solution...
-            isEnumeration = cellfun(@(cell) isenum(cell), table2cell(T(1,:)), 'uni', 1);
-            dataTypes(isEnumeration) = {'popup'};
-            enumerationIdx = find(isEnumeration);
-            for i = enumerationIdx
-                enumObject = T{1,i};
-                if iscell(enumObject); enumObject = enumObject{1}; end
-                [~, m] = enumeration( enumObject ); % need to get enum for original....
-                %colFormatData{i} = [C(1,i); m];
-                colFormatData{i} = m;
-            end
+        function value = get.AppRef(obj), value = obj.Backend.AppRef; end
+        function set.AppRef(obj, value), obj.Backend.AppRef = value; end
 
-            isCategorical = cellfun(@(cell) iscategorical(cell), table2cell(T(1,:)), 'uni', 1);
-            dataTypes(isCategorical) = {'popup'};
-            categoricalIdx = find(isCategorical);
-            for i = categoricalIdx
-                categoricalObject = T{1,i};
-                if iscell(categoricalObject); categoricalObject = categoricalObject{1}; end
-                if isprotected(categoricalObject)
-                    colFormatData{i} = categories(categoricalObject);
-                else
-                    % colFormatData{i} = categories(categoricalObject);
-                    
-                    % Add <undefined> as an option for unprotected categoricals
-                    % - Question: Does that responsibility lie here or upstream?
-                    colFormatData{i} = cat(1, '<undefined>', categories(categoricalObject));
-                end
-            end
+        function value = get.Parent(obj), value = obj.Backend.Parent; end
+        function set.Parent(obj, value), obj.Backend.Parent = value; end
 
-            % All numeric types should be called 'numeric'
-            isNumeric = cellfun(@(cell) isnumeric(cell), C(1,:), 'uni', 1);
-            dataTypes(isNumeric) = {'numeric'};
-            
-            isDatetime = cellfun(@(cell) isdatetime(cell), C(1,:), 'uni', 1);
-            dataTypes(isDatetime) = {'date'};
-            
-            % Todo: get from nansen preferences...
-            colFormatData(isDatetime) = {'MMM-dd-yyyy    '};
+        function value = get.HTable(obj), value = obj.Backend.HTable; end
+        function value = get.JTable(obj), value = obj.Backend.JTable; end
 
-            % NOTE: This is temporary. Need to generalize, not make special
-            % treatment for session table
-
-            isVarWithOptions = [obj.MetaTableVariableAttributes.HasOptions];
-            isValidType = strcmp([obj.MetaTableVariableAttributes.TableType], obj.MetaTableType);
-
-            customVarNames = {obj.MetaTableVariableAttributes(isVarWithOptions & isValidType).Name};
-            [customVarNames, iA] = intersect(variableNames, customVarNames);
-            
-            for i = 1:numel(customVarNames)
-                thisName = customVarNames{i};
-                tableVarIndex = strcmp({obj.MetaTableVariableAttributes.Name}, thisName);
-                
-                popupOptions = obj.MetaTableVariableAttributes(tableVarIndex).OptionsList;
-
-                dataTypes(iA(i)) = {'popup'};
-                if isa(popupOptions, 'cell') && numel(popupOptions) == 1
-                    colFormatData(iA(i)) = popupOptions;
-                else
-                    colFormatData(iA(i)) = {popupOptions};
-                end
-                obj.HTable.ColumnEditable(iA(i)) = true;
-            end
-
-            if any(strcmp(dataTypes, 'cell'))
-                error('The table contains values that can not be rendered. Please contact support.')
-            end
-            
-            % Update the column formatting properties
-            obj.HTable.ColumnFormatData = []; % Reset ColumnFormatData before changing ColumnFormat
-            obj.HTable.ColumnFormat = dataTypes;
-            obj.HTable.ColumnFormatData = colFormatData;
-
-            % Set column names. Do this last because this will control that
-            % the correct number of columns are shown.
-            obj.HTable.ColumnName = columnLabels;
-            
-            % Update indicators for table filters because these are reset
-            % when column name is set
-            obj.updateColumnLabelFilterIndicator()
-
-            obj.ColumnModel.updateJavaColumnModel()
-
-            % Maybe call this separately???
-            %obj.updateTableView()
-            
-            % Need to update theme...? I should really comment nonsensical
-            % stuff better.
-            obj.HTable.Theme = obj.HTable.Theme;
+        function value = get.ColumnContextMenu(obj), value = obj.Backend.ColumnContextMenu; end
+        function set.ColumnContextMenu(obj, value)
+            obj.Backend.ColumnContextMenu = value;
         end
 
-        function updateColumnLabelFilterIndicator(obj, filterActive)
-
-            if nargin < 2
-                filterActive = obj.ColumnFilter.isColumnFilterActive;
-            end
-
-            onColor = '#017100';
-
-            colIndices = obj.ColumnModel.getColumnIndices();
-            filterActive = filterActive(colIndices);
-
-            columnNames = obj.ColumnModel.getColumnNames();
-
-            for i = 1:numel(obj.HTable.ColumnName)
-                if ~isempty(filterActive) && filterActive(i)
-                    columnNames{i} = sprintf('<HTML><FONT color="%s">%s</Font>', onColor, columnNames{i});
-                    %columnNames{i} = sprintf('<HTML><FONT
-                    %color="%s"><b>%s</Font>', onColor, columnNames{i});
-                    %makes very bold
-                end
-            end
-            if ~isempty(columnNames)
-                obj.changeColumnNames(columnNames)
-            end
-        end
-        
-        function updateColumnEditable(obj)
-        %updateColumnEditable Update the ColumnEditable property of table
-        %
-        %   Set column editable, adjusting for which columns are currently
-        %   displayed and whether table should be editable or not.
-            
-            if isempty(obj.ColumnModel); return; end % On construction...
-            
-            % Set column editable (By default, none are editable)
-            allowEdit = obj.ColumnModel.getColumnIsEditable;
-            
-            [~, variableNames] = obj.ColumnModel.getColumnNames();
-            attributeColumnNames = {obj.MetaTableVariableAttributes.Name};
-            [~, ~, iC] = intersect(variableNames, attributeColumnNames, 'stable');
-            
-            isEditable = [obj.MetaTableVariableAttributes(iC).IsEditable];
-            allowEdit = allowEdit & isEditable;
-
-            % Set ignoreFlag to editable if options allow
-            columnNames = obj.ColumnModel.getColumnNames();
-            if obj.AllowTableEdits
-                allowEdit( contains(lower(columnNames), 'ignore') ) = true;
-                allowEdit( contains(lower(columnNames), 'description') ) = true;
-            else
-                allowEdit(:) = false;
-            end
-                        
-            obj.HTable.ColumnEditable = allowEdit;
-            
-        end
-        
-        function changeColumnNames(obj, newNames)
-            obj.HTable.ColumnName = newNames;
-        end % Todo: make dependent property and set method (?)
-        
-        function changeColumnWidths(obj, newWidths)
-            
-            if isa(obj.HTable, 'uim.widget.StylableTable')
-                % Use custom method of table model to set column width.
-                obj.HTable.changeColumnWidths(newWidths)
-            else
-                obj.HTable.ColumnWidth = newWidths;
-            end
-            
-        end % Todo: make dependent property and set method (?)
-        
-        function changeColumnToShow(obj)
-            
-        end % Todo: make dependent property and set method (?)
-        
-        function changeColumnOrder(obj)
-            % todo howdo
-        end
-    end
-    
-    methods (Access = private) % Update table & internal housekeeping
-                
-        function onMetaTableSet(obj, newTable)
-        %onMetaTableSet Internal callback for when the MetaTable property
-        %is set.
-        %
-        % Need to store the metatable as a cell array for presenting it in
-        % the UI table. (Relevant mostly for MetaTable objects because they
-        % might contain column data that needs to be formatted.
-            
-        % Todo: count number of columns of old and new;
-        % compare column names. If changed, reset/update column model...
-
-            if isa(newTable, 'nansen.metadata.MetaTable')
-                T = nansen.metadata.utility.formatTableForDisplay(newTable);
-                obj.MetaTableType = lower( newTable.getTableType() );
-                obj.MetaTableCell = table2cell(T);
-            elseif isa(newTable, 'table')
-                obj.MetaTableCell = table2cell(newTable);
-            end
-
-            % Update metatable variable attributes.
-            S = obj.getMetaTableVariableAttributes();
-            obj.MetaTableVariableAttributes = S;
-        end
-        
-        function onMetaTableTypeSet(obj, oldType, newType)
-            obj.RequireReset = ~strcmp(oldType, newType);
-        end
-
-        function onTableVariableAttributesFcnSet(obj)
-            S = obj.getMetaTableVariableAttributes();
-            obj.MetaTableVariableAttributes = S;
-            if obj.IsConstructed
-                obj.updateColumnLayout()
-            end
-        end
-
-        function onTableFontSizeSet(obj)
-            if ~isempty(obj.HTable)
-                obj.HTable.FontSize = obj.TableFontSize;
-                obj.HTable.RowHeight = obj.TableFontSize + 20;
-            end
-        end
-
-        function onColumnFilterSet(obj)
-        %onColumnFilterSet Callback for property value set.
-            if ~isempty(obj.FilterChangedListener)
-                delete(obj.FilterChangedListener)
-            end
-            
-            obj.FilterChangedListener = addlistener(obj.ColumnFilter, ...
-                'FilterUpdated', @obj.onFilterUpdated);
-        end
-        
-        function onFilterUpdated(obj, src, evt)
-        %onFilterUpdated Callback for table filter update events
-            
-            obj.updateTableView([], false)
-            
-            if ~isempty(obj.ExternalFilterMap)
-                visibleRows = find( obj.ExternalFilterMap );
-            else
-                visibleRows = 1:size(obj.MetaTableCell, 1);
-            end
-            
-            rows = obj.getCurrentRowSelection();
-            rows = intersect(rows, visibleRows, 'stable');
-            
-            evtdata = uiw.event.EventData('RowIndices', rows, 'Type', 'TableFilterUpdate');
-            obj.notify('TableUpdated', evtdata)
-        end
-        
-        function rowInd = getCurrentRowSelection(obj)
-            % Get row indices that are visible in the uitable
-
-            % Initialize the data filter map if it is empty.
-            [numRows, numColumns] = size(obj.MetaTableCell);
-            if isempty(obj.DataFilterMap)
-                obj.DataFilterMap = true(numRows, numColumns);
-            end
-            
-            % Remove ignored entries based on preference in settings.
-            if ~obj.ShowIgnoredEntries
-                
-                varNames = obj.MetaTable.Properties.VariableNames;
-                
-                isIgnoreColumn = contains(lower(varNames), 'ignore');
-                if any(isIgnoreColumn)
-                
-                    isIgnored = [ obj.MetaTableCell{:, isIgnoreColumn} ];
-                
-                    % Negate values of the ignore flag in the filter map
-                    obj.DataFilterMap(:, isIgnoreColumn) = ~isIgnored;
-                end
-            end
-            
-            % Get indices for rows where all cells in the map are true
-            rowInd = find( all(obj.DataFilterMap, 2) );
-            
-            if ~isempty(obj.ExternalFilterMap)
-                rowInd = intersect(rowInd, find(obj.ExternalFilterMap), 'stable');
-            end
-        end
-        
-        function colInd = getCurrentColumnSelection(obj)
-            % Get column indices that are visible in the uitable
-            if isempty(obj.ColumnModel); return; end % On construction...
-            
-            colInd = obj.ColumnModel.getColumnIndices();
-        end
-
-        function updateMetaTableVariableAttributes(obj)
-            obj.MetaTableVariableAttributes = ...
-                obj.getMetaTableVariableAttributes();
-        end
-
-        function S = getMetaTableVariableAttributes(obj)
-        % Get metatable variable attributes based on table type.
-
-            if ~isempty(obj.GetTableVariableAttributesFcn)
-                S = obj.GetTableVariableAttributesFcn(obj.MetaTableType);
-            else
-                S = obj.getDefaultMetaTableVariableAttributes();
-            end
-        end
-        
-        function S = getDefaultMetaTableVariableAttributes(obj)
-        %Get default table variable attributes from TableVariable class.
-            import nansen.metadata.abstract.TableVariable;
-            
-            varNames = obj.MetaTable.Properties.VariableNames;
-            numVars = numel(varNames);
-            S = TableVariable.getDefaultTableVariableAttribute();
-            S = repmat(S, 1, numVars);
-            
-            % Fill out names and table type
-            [S(1:numVars).Name] = varNames{:};
-            [S(1:numVars).TableType] = deal(obj.MetaTableType);
-        end
-    end
- 
-    methods (Access = private) % Mouse / user event callbacks
-        
-        function onHeaderPressTimerRunOut(obj, src, evt)
-            
-            if isempty(obj.ColumnPressedTimer)
+        function value = get.TableContextMenu(obj), value = obj.Backend.TableContextMenu; end
+        function set.TableContextMenu(obj, value)
+            obj.Backend.TableContextMenu = value;
+            if isa(obj.Backend, 'nansen.ui.metatable.EntityTableMetaTableViewer')
                 return
             end
-            
-            stop(obj.ColumnPressedTimer)
-            delete(obj.ColumnPressedTimer)
-            obj.ColumnPressedTimer = [];
-            
-            clickPosX = get(evt, 'X');
-            clickPosY = get(evt, 'Y');
-            obj.openColumnFilter(clickPosX, clickPosY)
-            
-        end
-
-        function onMousePressedInHeader(obj, src, evt)
-        %onMousePressedInHeader Handles mouse press in the table header.
-
-            buttonNum = get(evt, 'Button');
-            if get(evt,'Modifiers')==18,
-                buttonNum = 3;
-            end;            
-            obj.lastMousePressTic = tic;
-
-            % Need to call this to make sure filterdropdowns disappear if
-            % mouse is pressed in column header...
-            obj.ColumnFilter.hideFilters();
-            
-            % Check the cursor type of the mouse pointer. If it equals 11,
-            % it corresponds with the special case when the pointer is
-            % clicked on the border between to columns. In this case, abort.
-            if obj.HTable.JTable.getTableHeader().getCursor().getType() == 11
-                return
-            end
-            
-            % The action of pressing and holding for a split second should
-            % open the column filter. This is managed by a timer, and here,
-            % if a timer is not already active we start it and set the
-            % sortable to false
-            if buttonNum == 1 && get(evt, 'ClickCount') == 1
-                
-                if isempty(obj.ColumnPressedTimer)
-                    obj.ColumnPressedTimer = timer();
-                    obj.ColumnPressedTimer.Period = 1;
-                    obj.ColumnPressedTimer.StartDelay = 0.25;
-                    obj.ColumnPressedTimer.TimerFcn = @(s,e) obj.onHeaderPressTimerRunOut(s, evt);
-                    start(obj.ColumnPressedTimer)
-                    obj.HTable.JTable.getModel().setSortable(0)
-                end
-                
-            % For right clicks, open the context menu.
-            elseif buttonNum == 3 %rightclick
-                
-                % These are coords in table
-                clickPosX = get(evt, 'X');
-                clickPosY = get(evt, 'Y');
-                
-                % todo: get column header x- and y positions in figure.
-                obj.openColumnContextMenu(clickPosX, clickPosY);
+            if ~isempty(obj.Backend.HTable) && isvalid(obj.Backend.HTable) ...
+                    && isprop(obj.Backend.HTable, 'ContextMenu')
+                obj.Backend.HTable.ContextMenu = value;
             end
         end
-        
-        function onMouseDraggedInTableHeader(obj, src, evt)
-            
-            if ~isempty( obj.ColumnPressedTimer )
-                % Simulate mouse release to cancel the timer
-                obj.onMouseReleasedFromHeader([], [])
-            end
-            
-            dPos = (evt.MousePointCurrent -  evt.MousePointStart);
-            dS = sqrt(sum(dPos.^2));
-            
-            if dS > 10
-                if ~isempty(obj.ColumnFilter)
-                    obj.ColumnFilter.hideFilters();
-                end
-            end
+
+        function value = get.DataFilterMap(obj), value = obj.Backend.DataFilterMap; end
+        function set.DataFilterMap(obj, value), obj.Backend.DataFilterMap = value; end
+
+        function value = get.ExternalFilterMap(obj), value = obj.Backend.ExternalFilterMap; end
+        function set.ExternalFilterMap(obj, value), obj.Backend.ExternalFilterMap = value; end
+    end
+
+    methods (Access = private)
+        function notifySelectionChanged(obj, evt)
+            obj.notify('SelectionChanged', evt)
         end
-        
-        function onMouseReleasedFromHeader(obj, src, evt)
-                        
-            if ~isempty(obj.ColumnPressedTimer)
-                stop(obj.ColumnPressedTimer)
-                delete(obj.ColumnPressedTimer)
-                obj.ColumnPressedTimer = [];
-                
-                % Mouse was released before 1 second passed.
-                obj.HTable.JTable.getModel().setSortable(1)
-            end
-        end
-        
-        function onMousePressedInTable(obj, src, evt)
-        %onMousePressedInTable Callback for mousepress in table.
-        %
-        %   This function is primarily used for
-        %       1) Creating an action on doubleclick
-        %       2) Selecting cell on right click
 
-            % Return if instance is not valid.
-            if ~exist('obj', 'var') || ~isvalid(obj); return; end
-
-            obj.ColumnFilter.hideFilters()
-            if isempty(obj.MetaTable); return; end
-            obj.updateColumnEditable()
-
-            if strcmp(evt.SelectionType, 'normal')
-                % Do nothing.
-                % Get row where mouse press occurred.
-                row = evt.Cell(1); col = evt.Cell(2);
-                if row == 0 || col == 0
-                    obj.HTable.SelectedRows = [];
-                    
-                    % Make sure editable cell is not in focus when editing
-                    % is stopped, because it will be rendered with a black
-                    % background.
-                    colIdx = find( ~obj.HTable.ColumnEditable, 1, 'first');
-                    
-                    cellEditor = obj.HTable.JTable.getCellEditor();
-                    if ~isempty( cellEditor )
-                        cellEditor.stopCellEditing();
-                    end
-
-                    selectionModel = obj.HTable.JTable.getColumnModel.getSelectionModel;
-
-                    if ~isempty(colIdx)
-                        % Give focus to a non-editable cell.
-                        set(selectionModel, 'LeadSelectionIndex', colIdx-1)
-                    else
-                        % Set selection index to something near guaranteed
-                        % to not be in the current table (if no cells are
-                        % non-editable)
-                        set(selectionModel, 'LeadSelectionIndex', 9999)
-                    end
-                end
-                    
-            elseif strcmp(evt.SelectionType, 'open')
-            
-                if ~isempty(obj.MouseDoubleClickedFcn)
-                    obj.MouseDoubleClickedFcn(src, evt)
-                else
-                    obj.onMouseDoubleClickedInTable(src, evt)
-                end
-                
-                % Todo:
-                % Double click action should depend on which column click
-                % happens over.
-
-% %                     if isequal(get(event, 'button'), 3)
-% %                         return
-% %                     end
-% %
-% %                     currentFields = app.tableSettings.FieldNames(app.tableSettings.FieldsToShow);
-% %                     so = retrieveSessionObject(app, app.highlightedSessions(end));
-% %
-% %                     if numel(app.highlightedSessions) > 1
-% %                         warning('Multiple sessions, selected, operation applies to last session only.')
-% %                     end
-% %
-% %                     if strcmp(currentFields{j+1}, 'Notes')
-% %                         app.showNotes(so.sessionID)
-% %                     else
-% %                         %so.openFolder
-% %                         openFolder(so.sessionID, 'datadrive', 'processed')
-% %                     end
-                    
-            elseif evt.Button == 3 || strcmp(evt.SelectionType, 'alt')
-                
-                if ismac && evt.Button == 1 && evt.MetaOn
-                    return % Command click on mac should not count as right click
-                end
-
-                if ispc && evt.Button == 1 && evt.ControlOn
-                    return % Control click on windows should not count as right click
-                end
-
-                % Get row where mouse press occurred.
-                row = evt.Cell(1); col = evt.Cell(2);
-                
-                % Select row where mouse is pressed if it is not already
-                % selected
-                if ~ismember(row, obj.HTable.SelectedRows)
-                    if row > 0 && col > 0
-                        obj.HTable.SelectedRows = row;
-                    else
-                        obj.HTable.SelectedRows = [];
-                        return
-                    end
-                end
-
-                % Open context menu for table
-                if ~isempty(obj.TableContextMenu)
-                    position = obj.getTableContextMenuPosition(evt.Position);
-                    obj.openTableContextMenu(position(1), position(2));
-                end
-            end
-        end  
-                    
-        function onMouseDoubleClickedInTable(obj, src, evt)
-        % onMouseDoubleClickedInTable - Callback for double clicks
-        %
-        %   Check if the currently selected column has an associated table
-        %   variable definition with a double click callback function.
-
-        % Note: currently not used
-
-            thisRow = evt.Cell(1); % Clicked row index
-            thisCol = evt.Cell(2); % Clicked column index
-            
-            if thisRow == 0 || thisCol == 0
-                return
-            end
-            
-            % Get name of column which was clicked
-            thisColumnName = obj.getColumnNames(thisCol);
-
-            % Use table variable attributes to check if a double click 
-            % callback function exists for the current table column
-            TVA = obj.MetaTableVariableAttributes([obj.MetaTableVariableAttributes.HasDoubleClickFunction]);
-            
-            isMatch = strcmp(thisColumnName, {TVA.Name});
-
-            if any( isMatch )
-                tableVariableClassName = TVA(isMatch).ClassName;
-
-                if ~isempty(tableVariableClassName)
-                    tableRowIdx = app.UiMetaTableViewer.getMetaTableRows(thisRow); % Visible row to data row transformation
-                    tableValue = app.MetaTable.entries{tableRowIdx, thisColumnName};
-                    tableVariableObj = feval(tableVariableClassName, tableValue);
-                    
-                    tableRowData = app.MetaTable.entries(tableRowIdx,:);
-                    metaObj = app.tableEntriesToMetaObjects( tableRowData );
-                    tableVariableObj.onCellDoubleClick( metaObj );
-                else
-                    if isa(TVA(isMatch).DoubleClickFunctionName, 'function_handle')
-                        TVA(isMatch).DoubleClickFunctionName()
-                    else
-                        error('Not supported')
-                    end
-                end
-            end
-        end
-        
-
-        function onMouseMotionInTable(obj, src, evt)
-            % This functionality is put in the nansen app for now.
-        end
-        
-        function onCellValueEdited(obj, src, evtData)
-        %onCellValueEdited Callback for value change in cell
-        %
-        %   1) Update original table data
-        %   2) Modify evtData and pass on to class' CellEditCallback
-            
-        % Todo: For time being (oct2021) the only editable column is the
-        % ignore flag column. Should refresh the table if ignore rows are
-        % set to hidden, but for now, the ignored rows will disappear on
-        % next table update.
-        
-            % Get currently visible row and column indices.
-            rowInd = obj.getCurrentRowSelection();
-            colInd = obj.getCurrentColumnSelection();
-            
-            % Get row and column indices for original data (unfiltered, unsorted, allcolumns)
-            tableRowInd = rowInd(evtData.Indices(1));
-            
-            evtColIdx = obj.ColumnModel.getColumnIdx( evtData.Indices(2) ); % 2 is for columns
-            tableColInd = colInd(evtColIdx);
-            
-            % Todo: Implement this, if dropdown contains actionable options
-            % formatted like this: <action name>
-            % % newValue = evtData.NewValue;
-            % % if startsWith(newValue, '<') && endsWith(newValue, '>')
-            % %     evtData.NewValue = [];
-            % % end
-            
-            % Update value in table and table cell array
-            %obj.MetaTable(tableRowInd, tableColInd) = {evtData.NewValue};
-            obj.MetaTableCell{tableRowInd, tableColInd} = evtData.NewValue;
-            
-            % Invoke external callback if it is assigned.
-            if ~isempty( obj.CellEditCallback )
-                evtData.Indices = [tableRowInd, tableColInd];
-                obj.CellEditCallback(src, evtData)
-            end
-        end
-        
-        function onCellSelectionChanged(obj, src, evt)
-            %evtData = event.EventData;
-            evtData = uiw.event.EventData('SelectedRows', evt.SelectedRows);
-            obj.notify('SelectionChanged', evtData)
-        end
-        
-        function onColumnWidthChanged(obj, src, event)
-        %onColumnWidthChanged Callback for events where column widths are
-        %changed by resizing column widths in from gui.
-            obj.ColumnModel.setColumnWidths(obj.HTable.ColumnWidth)
-        end
-        
-        function onColumnsRearranged(obj, src, evt)
-        %onColumnsRearranged Callback for event when columns are rearranged
-        %
-        % This event is triggered when user drags columns to rearrange
-            
-            % Tell columnmodel of new order...
-            newColumnArrangement = obj.HTable.getColumnOrder;
-            obj.ColumnModel.setNewColumnOrder(newColumnArrangement)
-                        
-            if ~isempty(obj.ColumnFilter)
-                obj.ColumnFilter.hideFilters();
-            end
-        end
-        
-        function columnIdx = getColumnAtPoint(obj, x, y)
-        %getColumnAtPoint Returns the column index at point (x,y)
-        %
-        %   Conversion from java to matlab:
-            
-            mPos = java.awt.Point(x, y);
-            columnIdx = obj.HTable.JTable.columnAtPoint(mPos) + 1;
-            % Note, java indexing starts at 0, so added 1.
-            
-        end
-        
-        function position = getTableContextMenuPosition(obj, eventPosition)
-        %getTableContextMenuPosition Get cmenu position from event position
-        
-            % Get scroll positions in table
-            xScroll = obj.HTable.getHorizontalScrollOffset();
-            yScroll = obj.HTable.getVerticalScrollOffset();
-                        
-            % Get position where mouseclick occurred (in figure)
-            clickPosX = eventPosition(1) - xScroll;
-            clickPosY = eventPosition(2) - yScroll;
-            
-            % Convert to position inside table
-            tablePosition = getpixelposition(obj.HTable, true);
-            tableLocationX = tablePosition(1);
-            tableHeight = tablePosition(4);
-            
-            positionX = clickPosX + tableLocationX + 1; % +1 because ad hoc...
-            % obj.HTable.RowHeight??
-            positionY = tableHeight - clickPosY + 19; % +15 because ad hoc... size of table header?
-            position = [positionX, positionY];
-            
-        end
-        
-        function figureCoords = javapoint2figurepoint(obj, javaCoords)
-        %javapoint2figurepoint Find coordinates of point in figure units
-        %
-        %   figureCoords = javapoint2figurepoint(obj, javaCoords) returns
-        %   figureCoords ([x,y]) of point in figure (measured from lower
-        %   left corner) based on javaCoords ([x,y]) from a java mouse
-        %   event in the table (measured from upper left corner in table).
-        
-            % Note:
-            % x is position measured from left inside table
-            % y is position measured from top inside table
-
-            % Get pixel position of table referenced in figure.
-            tablePosition = getpixelposition(obj.HTable, true);
-            
-            x0 = tablePosition(1);
-            y0 = tablePosition(2);
-            tableHeight = tablePosition(4);
-            
-            xPosition = x0 + javaCoords(1);
-            yPosition = y0 + tableHeight - javaCoords(2);
-             
-            figureCoords = [xPosition, yPosition];
-            
-        end
-        
-        function openColumnContextMenu(obj, x, y)
-            
-            colNumber = obj.getColumnAtPoint(x, y);
-            if colNumber == 0; return; end
-            
-            if isempty(obj.ColumnContextMenu)
-                obj.createColumnContextMenu()
-            end
-            
-            % Get column name of column where context menu should open
-            [~, varNames] = obj.ColumnModel.getColumnNames();
-            currentColumnName = varNames{colNumber};
-            
-            % Get column number according to the underlying java column
-            % models column order.
-            [colIdxJava, ~] = obj.ColumnModel.getColumnModelIndexOrder();
-            colNumber = colIdxJava(colNumber);
-            
-            columnType = obj.HTable.ColumnFormat{colNumber};
-            
-            isMatch = strcmp( {obj.MetaTableVariableAttributes.Name}, currentColumnName ) & ...
-                contains([obj.MetaTableVariableAttributes.TableType], obj.MetaTableType, 'IgnoreCase', true);
-            if any(isMatch)
-                varAttr = obj.MetaTableVariableAttributes(isMatch);
-            else
-                error('Variable attributes does not exist. This is unexpected.')
-            end
-            
-            % Select appearance of context menu based on column type:
-            for i = 1:numel(obj.ColumnContextMenu.Children)
-                hTmp = obj.ColumnContextMenu.Children(i);
-                
-                switch hTmp.Tag
-                    case 'Sort Ascend'
-                        switch columnType
-                            case 'char'
-                                hTmp.Label = 'Sort A-Z';
-                            case 'numeric'
-                                hTmp.Label = 'Sort low-high';
-                            case 'logical'
-                                hTmp.Label = 'Sort false-true';
-                        end
-                        hTmp.Callback = @(s,e,iCol,dir) obj.sortColumn(colNumber,'ascend');
-
-                    case 'Sort Descend'
-                        switch columnType
-                            case 'char'
-                                hTmp.Label = 'Sort Z-A';
-                            case 'numeric'
-                                hTmp.Label = 'Sort high-low';
-                            case 'logical'
-                                hTmp.Label = 'Sort true-false';
-                        end
-                        hTmp.Callback = @(s,e,iCol,dir) obj.sortColumn(colNumber,'descend');
-                        
-                    case 'Filter'
-                        hTmp.Callback = @(s,e,iCol) obj.filterColumn(colNumber);
-                    case 'Reset Filters'
-                        hTmp.Callback = @(s,e,iCol) obj.resetColumnFilters();
-                        
-                    case 'Hide Column'
-                        hTmp.Callback = @(s,e,iCol) obj.hideColumn(colNumber);
-                        
-                    case 'Update Column'
-                        if varAttr.HasUpdateFunction % (Does it have to be custom?)% varAttr.IsCustom && varAttr.HasUpdateFunction
-                            hTmp.Enable = 'on';
-                            if ~isempty(obj.UpdateColumnFcn)
-                                % Children are reversed from creation
-                                hTmp.Children(1).Callback = @(s,e,name) obj.EditColumnFcn(currentColumnName);
-                                hTmp.Children(2).Callback = @(name, mode) obj.ResetColumnFcn(currentColumnName, 'AllRows');
-                                hTmp.Children(3).Callback = @(name, mode) obj.ResetColumnFcn(currentColumnName, 'SelectedRows');
-                                hTmp.Children(4).Callback = @(name, mode) obj.UpdateColumnFcn(currentColumnName, 'AllRows');
-                                hTmp.Children(5).Callback = @(name, mode) obj.UpdateColumnFcn(currentColumnName, 'SelectedRows');
-                            end
-                        else
-                            hTmp.Enable = 'off';
-                        end
-                        
-                    case 'Delete Column'
-                        if varAttr.IsCustom
-                            hTmp.Enable = 'on';
-                            if ~isempty(obj.DeleteColumnFcn)
-                                hTmp.Callback = @(colName, evt) obj.DeleteColumnFcn(currentColumnName);
-                            end
-                        else
-                            hTmp.Enable = 'off';
-                        end
-                        
-                    otherwise
-                        % Do nothing
-                end
-            end
-
-            % Get the coordinates for where to show the context menu
-            figurePoint = obj.javapoint2figurepoint([x, y]);
-            
-            % Adjust for the horizontal scroll position in the table.
-            xOff = obj.HTable.getHorizontalScrollOffset();
-            figurePoint = figurePoint - [xOff, 0];
-            
-            % Set position and make menu visible.
-            obj.ColumnContextMenu.Position = figurePoint;
-            obj.ColumnContextMenu.Visible = 'on';
-            
-        end
-        
-        function openTableContextMenu(obj, x, y)
-            
-            if isempty(obj.TableContextMenu); return; end
-
-            % Set position and make menu visible.
-            obj.TableContextMenu.Position = [x,y];
-            obj.TableContextMenu.Visible = 'on';
-            
-        end
-        
-        function openColumnFilter(obj, x, y)
-        %openColumnFilter Open column filter as dropdown below column header
-            
-            tableColumnIdx = obj.getColumnAtPoint(x, y);
-            if tableColumnIdx == 0; return; end
-            
-            colIndices = obj.ColumnModel.getColumnIndices();
-            dataColumnIndex = colIndices(tableColumnIdx);
-            
-            obj.ColumnFilter.openFilterControl(dataColumnIndex)
-
-        end
-        
-        function filterColumn(obj, columnNumber)
-        %filterColumn Open column filter in sidepanel
-        
-            colIndices = obj.ColumnModel.getColumnIndices();
-            dataColumnIndex = colIndices(columnNumber);
-            
-            obj.ColumnFilter.openFilterControl(dataColumnIndex)
-            obj.AppRef.showSidePanel()
-            
-        end
-        
-        function sortColumn(obj, columnIdx, sortDirection)
-        %sortColumn Sort column in specified direction
-            sortAscend = strcmp(sortDirection, 'ascend');
-            sortDescend = strcmp(sortDirection, 'descend');
-            
-            obj.HTable.JTable.sortColumn(columnIdx-1, 1, sortAscend)
-
-        end
-        
-        function hideColumn(obj, columnNumber)
-        	obj.ColumnModel.hideColumn(columnNumber);
+        function notifyTableUpdated(obj, evt)
+            obj.notify('TableUpdated', evt)
         end
     end
-    
+
     methods (Static)
-        
         function tf = isValidTableClass(var)
         %isValidTable Test if var satisfies the list of valid table classes
-            VALID_CLASSES = nansen.MetaTableViewer.VALID_TABLE_CLASS;
-            tf = any(cellfun(@(type) isa(var, type), VALID_CLASSES));
+            validClasses = nansen.MetaTableViewer.VALID_TABLE_CLASS;
+            tf = any(cellfun(@(type) isa(var, type), validClasses));
         end
     end
 end

--- a/code/apps/+nansen/SessionTaskMenu.m
+++ b/code/apps/+nansen/SessionTaskMenu.m
@@ -330,12 +330,10 @@ classdef SessionTaskMenu < handle
             
             % Create new menu item if menu with this label does not exist
             if isempty(hMenuItem)
+                hMenuItem = uimenu(hParent, 'Text', menuName, 'Tag', menuName);
                 if isa(hParent, 'matlab.ui.Figure')
-                    styledMenuName = obj.styleTopLevelMenuTitle(menuName);
-                else
-                    styledMenuName = menuName;
+                    obj.styleTopLevelMenuTitle(hMenuItem, menuName);
                 end
-                hMenuItem = uimenu(hParent, 'Text', styledMenuName, 'Tag', menuName);
                 obj.hMenuDirs(end+1) = hMenuItem;
             end
             
@@ -533,9 +531,33 @@ classdef SessionTaskMenu < handle
             end
         end
         
-        function menuName = styleTopLevelMenuTitle(obj, menuName)
-            menuName = sprintf('<HTML><FONT color="%s">%s</Font></HTML>', ...
-                obj.TitleColor, menuName);
+        function styleTopLevelMenuTitle(obj, hMenuItem, menuName)
+            if nansen.util.useModernUiComponents()
+                hMenuItem.Text = menuName;
+                if isprop(hMenuItem, 'ForegroundColor')
+                    hMenuItem.ForegroundColor = obj.getTitleColorRgb();
+                end
+            else
+                hMenuItem.Text = sprintf('<HTML><FONT color="%s">%s</Font></HTML>', ...
+                    obj.TitleColor, menuName);
+            end
+        end
+
+        function rgb = getTitleColorRgb(obj)
+            if isnumeric(obj.TitleColor)
+                rgb = obj.TitleColor;
+                return
+            end
+
+            hexColor = char(obj.TitleColor);
+            hexColor = strrep(hexColor, '#', '');
+            if numel(hexColor) ~= 6
+                rgb = [0 0 0];
+                return
+            end
+            rgb = [hex2dec(hexColor(1:2)), ...
+                   hex2dec(hexColor(3:4)), ...
+                   hex2dec(hexColor(5:6))] ./ 255;
         end
 
         function resetSkipRefreshFlag(obj)

--- a/code/apps/+nansen/uiwTaskTable.m
+++ b/code/apps/+nansen/uiwTaskTable.m
@@ -150,7 +150,8 @@ classdef uiwTaskTable < uiw.mixin.AssignPVPairs
 
         function setKeyPressFcn(obj, keyPressFcn)
             obj.KeyPressFcn = keyPressFcn;
-            if ~isempty(obj.Table) && isvalid(obj.Table) && isprop(obj.Table, 'KeyPressFcn')
+            if ~isempty(keyPressFcn) && ~isempty(obj.Table) && ...
+                    isvalid(obj.Table) && isprop(obj.Table, 'KeyPressFcn')
                 obj.Table.KeyPressFcn = keyPressFcn;
             end
         end
@@ -215,7 +216,7 @@ classdef uiwTaskTable < uiw.mixin.AssignPVPairs
                 tableHandle.Multiselect = 'on';
                 tableHandle.CellEditCallback = @obj.onCellEdited;
                 tableHandle.SelectionChangedFcn = @obj.onModernSelectionChanged;
-                if isprop(tableHandle, 'KeyPressFcn')
+                if ~isempty(obj.KeyPressFcn) && isprop(tableHandle, 'KeyPressFcn')
                     tableHandle.KeyPressFcn = obj.KeyPressFcn;
                 end
 
@@ -236,7 +237,7 @@ classdef uiwTaskTable < uiw.mixin.AssignPVPairs
                 'MouseClickedCallback', @obj.onLegacyMouseClicked);
 
                 tableHandle.CellEditCallback = @obj.onCellEdited;
-                if isprop(tableHandle, 'KeyPressFcn')
+                if ~isempty(obj.KeyPressFcn) && isprop(tableHandle, 'KeyPressFcn')
                     tableHandle.KeyPressFcn = obj.KeyPressFcn;
                 end
 

--- a/code/graphics/+applify/helpDialog.m
+++ b/code/graphics/+applify/helpDialog.m
@@ -90,12 +90,10 @@ function helpDialog(functionName)
     uim.utility.centerFigureOnScreen(helpfig)
     helpfig.Visible = 'on';
     
-    warning('off', 'MATLAB:ui:javaframe:PropertyToBeRemoved')
-    
-    % Close help window if it loses focus
-    jframe = getjframe(helpfig);
-    set(jframe, 'WindowDeactivatedCallback', @(s, e) delete(helpfig))
-    
-    warning('on', 'MATLAB:ui:javaframe:PropertyToBeRemoved')
-
+    if nansen.util.isJavaFrameSupported()
+        % Close help window if it loses focus
+        warnCleanup = nansen.ui.legacy.tempDisableJavaFrameWarnings(); %#ok<NASGU>    
+        jframe = getjframe(helpfig);
+        set(jframe, 'WindowDeactivatedCallback', @(s, e) delete(helpfig))
+    end
 end

--- a/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/DataLocation.m
+++ b/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/DataLocation.m
@@ -19,7 +19,7 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
 
         % Value struct
     end
-   
+
     methods
         function obj = DataLocation(S)
             if nargin < 1; S = struct.empty; end
@@ -27,24 +27,24 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
             assert( all( arrayfun(@isstruct, [obj.Value])), 'Value must be a struct')
         end
     end
-    
+
     methods
-        
+
         function str = getCellDisplayString(obj)
         %getCellDisplayString Get character vector to display in table cell
-            
+
         % todo: vectorize
-            
+
             % Assume that the current datalocation model is valid. This
             % is a weak assumption, since it is in theory possible to have
             % a call this function with values from sessions/metatables
             % that are not part of the current project...
             dataLocationModel = nansen.DataLocationModel();
-            
+
             str = cell(numel(obj), 1);
-            
+
             for i = 1:numel(obj)
-                
+
                 if ~isfield(obj(i).Value, 'Uuid')
                     dataLocationNames = fieldnames(obj(i).Value);
                 else % legacy code (when each dataloc is a field...):
@@ -53,12 +53,12 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                     end
                     dataLocationNames = {obj(i).Value.Name};
                 end
-                
+
                 numDataLocations = numel(dataLocationNames);
                 thisStr = '<html>';
 
                 for j = 1:numDataLocations
-                    
+
                     if isfield(obj(i).Value, 'RootPath')
                         rootPath = obj(i).Value(j).RootPath;
                         subFolder = obj(i).Value(j).Subfolders;
@@ -75,7 +75,7 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                             subFolder = fileparts(subFolder);
                         end
                     end
-                    
+
                     if isempty(rootPath)
                         tmpStr = obj.getIconHtmlString('dot_off');
                     elseif isfolder(fullfile(rootPath, subFolder)) && ~isempty(subFolder)
@@ -94,28 +94,105 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                 if numDataLocations == 0
                     thisStr = sprintf('%d Datalocations', numDataLocations);
                 end
-                
+
                 str{i} = thisStr;
             end
         end
-       
+
+        function str = getCellDisplayStringForContext(obj, displayContext)
+            if nargin < 2 || isempty(displayContext)
+                displayContext = "legacy";
+            end
+            displayContext = lower(string(displayContext));
+            if displayContext == "modern"
+                str = obj.getEmojiCellDisplayString();
+            else
+                str = obj.getCellDisplayString();
+            end
+        end
+
+        function str = getEmojiCellDisplayString(obj)
+        %getEmojiCellDisplayString Get HTML text display using emoji entities.
+
+        % todo: vectorize
+
+            dataLocationModel = nansen.DataLocationModel();
+
+            str = cell(numel(obj), 1);
+
+            for i = 1:numel(obj)
+
+                if ~isfield(obj(i).Value, 'Uuid')
+                    dataLocationNames = fieldnames(obj(i).Value);
+                else % legacy code (when each dataloc is a field...):
+                    if ~isfield(obj(i).Value, 'Name')
+                        obj(i).Value = dataLocationModel.expandDataLocationInfo(obj(i).Value);
+                    end
+                    dataLocationNames = {obj(i).Value.Name};
+                end
+
+                numDataLocations = numel(dataLocationNames);
+                thisStr = '<html>';
+
+                for j = 1:numDataLocations
+
+                    if isfield(obj(i).Value, 'RootPath')
+                        rootPath = obj(i).Value(j).RootPath;
+                        subFolder = obj(i).Value(j).Subfolders;
+                    else % legacy code (when each dataloc is a field...):
+                        rootPath = obj(i).Value.(dataLocationNames{j});
+                        subFolder = rootPath;
+                    end
+
+                    % Subfolder might be a file, if using "virtual" folder
+                    % mode where a folder level is actually consisting of
+                    % files and not subfolders.
+                    if ~isempty(rootPath)
+                        if isfile(fullfile(rootPath, subFolder))
+                            subFolder = fileparts(subFolder);
+                        end
+                    end
+
+                    if isempty(rootPath)
+                        tmpStr = obj.getEmojiHtmlString('dot_off');
+                    elseif isfolder(fullfile(rootPath, subFolder)) && ~isempty(subFolder)
+                        tmpStr = obj.getEmojiHtmlString('dot_on');
+                    elseif isempty(subFolder)
+                        tmpStr = obj.getEmojiHtmlString('dot_off');
+                    elseif isfolder(subFolder) % ref legacy...
+                        tmpStr = obj.getEmojiHtmlString('dot_on');
+                    else
+                        tmpStr = obj.getEmojiHtmlString('dot_none');
+                    end
+
+                    thisStr = strcat(thisStr, tmpStr);
+                end
+
+                if numDataLocations == 0
+                    thisStr = sprintf('%d Datalocations', numDataLocations);
+                end
+
+                str{i} = thisStr;
+            end
+        end
+
         function str = getCellTooltipString(obj)
         %getCellTooltipString Get character vector to display as tooltip
-        
+
             datalocStruct = obj.Value;
-            
+
             if isa(datalocStruct, 'cell')
                 datalocStruct = datalocStruct{1};
             end
-            
+
             if isempty(datalocStruct)
                 str = '';
-            
+
             else
                 % Create a html formatted string from values in struct
                 str = cell(size(datalocStruct));
                 strtab = '&nbsp;&nbsp;&nbsp;&nbsp;';
-                
+
                 for i = 1:numel(datalocStruct)
                     str{i} = sprintf(['%s (%s)',...
                         '<br/>%s Root Number: %d', ...
@@ -128,52 +205,52 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                         strtab, datalocStruct(i).RootPath, ...
                         strtab, datalocStruct(i).Subfolders);
                 end
-                
+
                 str = strjoin(str, '<br /><br />'); % Add blank line between data locations
                 str = sprintf('<html><div align="left"> %s </div>', str);
             end
         end
-        
+
         function onCellDoubleClick(obj, metaObj)
         %onCellDoubleClick Callback for doubleclick on table cell
         %
         % Open ui editor for changing data location root and subfolders.
         % Each data location gets its own page
-            
+
             if ~isempty(obj.Value)
-                
+
                 S = struct();
                 for i = 1:metaObj.DataLocationModel.NumDataLocations
                     thisDataLoc = metaObj.DataLocationModel.Data(i);
-                    
+
                     fieldName = thisDataLoc.Name;
-                                        
+
                     rootPath = metaObj.getDataLocationRootDir(fieldName);
                     allRootPaths = {thisDataLoc.RootPath.Value};
-                    
+
                     if isempty(rootPath)
                         rootPath = '';
                     end
-                    
+
                     if ~any(strcmp(rootPath, allRootPaths))
                         allRootPaths = [{rootPath}, allRootPaths];
                     end
-                    
+
                     S.(fieldName).RootPath = rootPath;
                     S.(fieldName).RootPath_ = allRootPaths;
-                       
+
                     S.(fieldName).Subfolder = obj.Value(i).Subfolders;
                     if isempty(S.(fieldName).Subfolder)
                         if isa(S.(fieldName).Subfolder, 'double')
                             S.(fieldName).Subfolder = '';
                         end
                     end
-                    
+
                     %structeditor is not advanced enough for this yet..
                     % todo for the future
                     %S.(fieldName).Subfolder_ = @(x)uigetdir(rootPath);
                 end
-                
+
                 h = structeditor.App(S, 'AdjustFigureSize', true, ...
                     'Title', 'Edit Data Location Rootpaths', ...
                     'LabelPosition', 'over', ...
@@ -183,7 +260,7 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                 h.Title = sprintf('Edit Data Locations for %s', metaObj.sessionID);
 
                 h.waitfor()
-                
+
                 if h.wasCanceled
                     return
                 else
@@ -194,7 +271,7 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                 end
             end
         end
-        
+
         function onCellDoubleClick2(obj, metaObj)
         %onCellDoubleClick Callback for doubleclick on table cell
         %
@@ -203,29 +280,29 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
         % data location
 
             if ~isempty(obj.Value)
-                
+
                 S = struct();
                 for i = 1:metaObj.DataLocationModel.NumDataLocations
                     thisDataLoc = metaObj.DataLocationModel.Data(i);
-                    
+
                     fieldName = thisDataLoc.Name;
                     fieldName_ = strcat(fieldName, '_');
-                    
+
                     rootPath = metaObj.getDataLocationRootDir(fieldName);
                     allRootPaths = {thisDataLoc.RootPath.Value};
-                    
+
                     if isempty(rootPath)
                         rootPath = '';
                     end
-                    
+
                     S.(fieldName) = rootPath;
                     if ~any(strcmp(rootPath, allRootPaths))
                         allRootPaths = [{rootPath}, allRootPaths];
                     end
                     S.(fieldName_) = allRootPaths;
-                    
+
                 end
-                
+
                 h = structeditor.App(S, 'AdjustFigureSize', true, ...
                     'Title', 'Edit Data Location Rootpaths', ...
                     'LabelPosition', 'over', ...
@@ -233,7 +310,7 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
                 h.Title = sprintf('Edit Data Locations for %s', metaObj.sessionID);
 
                 h.waitfor()
-                
+
                 if h.wasCanceled
                     return
                 else
@@ -245,10 +322,10 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
             end
         end
     end
-    
+
     methods (Access = ?structeditor.App)
         function onDataLocationChanged(obj, src, evt)
-            
+
             switch evt.Name
                 case 'Subfolder'
                     rootDirValue = evt.UIControls.RootPath.String{evt.UIControls.RootPath.Value};
@@ -261,24 +338,24 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
             end
         end
     end
-    
+
     methods (Static)
-        
+
         function value = updateDataLocation(sessionObj)
-                  
+
             % Todo: Change name to update when finished. then datalocation
             % will be updatable from sessionbrowser.
-            
+
             % Todo: Make sure root uid is assigned correctly...
-            
+
             error('not implemented')
             value = sessionObj.DataLocation;
-            
+
             dataLocationModel = sessionObj.DataLocationModel;
-            
+
             % Todo: Make sure this works even if rootpath identity
             % changed..
-            
+
             for i = 1:numel(dataLocationModel.Data)
                 thisLoc = dataLocationModel.Data(i);
                 pathString = sessionObj.detectSessionFolder(thisLoc);
@@ -286,17 +363,17 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
 
                     folders = strsplit(pathString, filesep);
                     numFolders = numel(thisLoc.SubfolderStructure);
-                    
+
                     value(i).RootPath = strjoin(folders(1:end-numFolders), filesep);
                     value(i).Subfolders = strjoin(folders(end-numFolders+1:end), filesep);
-                    
+
                 end
             end
         end
     end
-   
+
     methods (Static)
-        
+
         function str = getIconHtmlString(iconName, iconSize)
         %getIconHtmlString Return html string for icon with given name
         %
@@ -306,17 +383,34 @@ classdef DataLocation < nansen.metadata.abstract.TableVariable & nansen.metadata
         %
         %   Input:
         %       iconName : 'dot_on' | 'dot_off'
-        
+
             if nargin < 2
                 iconSize = 16;
             end
-            
+
             folderPath = nansen.common.constant.TableVariableTemplateDirectory();
             iconPath = fullfile(folderPath, '_symbols', sprintf('%s.png', iconName));
-            
+
             sizeSpec = sprintf('width="%d" height="%d"', iconSize, iconSize);
             str = sprintf('<img src="file:%s" %s margin="0">', iconPath, sizeSpec);
-            
+
+        end
+
+        function str = getEmojiHtmlString(iconName)
+        %getEmojiHtmlString Return HTML entity for modern uitable status icon.
+
+            switch iconName
+                case 'dot_on'
+                    htmlEntity = '&#128994;'; % green circle
+                case 'dot_off'
+                    htmlEntity = '&#128308;'; % red circle
+                case 'dot_none'
+                    htmlEntity = '&#128993;'; % yellow circle
+                otherwise
+                    htmlEntity = '';
+            end
+
+            str = sprintf('%s&nbsp;', htmlEntity);
         end
     end
 end

--- a/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/Notebook.m
+++ b/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/Notebook.m
@@ -82,6 +82,58 @@ classdef Notebook < nansen.metadata.abstract.TableVariable & nansen.metadata.abs
                 str{i} = formattedStr;
             end
         end
+
+        function str = getCellDisplayStringForContext(obj, displayContext)
+            if nargin < 2 || isempty(displayContext)
+                displayContext = "legacy";
+            end
+            displayContext = lower(string(displayContext));
+            if displayContext == "modern"
+                str = obj.getEmojiCellDisplayString();
+            else
+                str = obj.getCellDisplayString();
+            end
+        end
+
+        function str = getEmojiCellDisplayString(obj)
+        %getEmojiCellDisplayString Get HTML text display using emoji entities.
+
+            str = cell(1, numel(obj));
+
+            for i = 1:numel(obj)
+                noteStruct = obj(i).Value;
+
+                if iscell(noteStruct)
+                    noteStruct = noteStruct{1};
+                end
+
+                str{i} = sprintf('%d Notes', numel(noteStruct));
+                if isempty(noteStruct)
+                    continue
+                end
+
+                formattedStr = sprintf('<html>%s&nbsp;', str{i});
+                noteTypes = string({noteStruct.Type});
+
+                if any(strcmpi(noteTypes, "Informal"))
+                    formattedStr = strcat(formattedStr, obj.getEmojiHtmlString('informal'));
+                end
+
+                if any(strcmpi(noteTypes, "Important"))
+                    formattedStr = strcat(formattedStr, obj.getEmojiHtmlString('important'));
+                end
+
+                if any(strcmpi(noteTypes, "Question"))
+                    formattedStr = strcat(formattedStr, obj.getEmojiHtmlString('question'));
+                end
+
+                if any(strcmpi(noteTypes, "Todo"))
+                    formattedStr = strcat(formattedStr, obj.getEmojiHtmlString('todo'));
+                end
+
+                str{i} = formattedStr;
+            end
+        end
        
         function str = getCellTooltipString(obj)
            
@@ -146,6 +198,25 @@ classdef Notebook < nansen.metadata.abstract.TableVariable & nansen.metadata.abs
             iconPath = sprintf( '/Applications/MATLAB_R2017b.app/toolbox/matlab/uitools/private/icon_%s_32.png', iconName);
             str = sprintf('<img src="file:%s" width="10" height="10" margin="0">', iconPath);
             
+        end
+
+        function str = getEmojiHtmlString(noteType)
+        %getEmojiHtmlString Return HTML entity for notebook note types.
+
+            switch lower(noteType)
+                case 'informal'
+                    htmlEntity = '&#8505;&#65039;'; % information
+                case 'important'
+                    htmlEntity = '&#9888;&#65039;'; % warning
+                case 'question'
+                    htmlEntity = '&#10067;'; % question mark
+                case 'todo'
+                    htmlEntity = '&#128221;'; % memo
+                otherwise
+                    htmlEntity = '';
+            end
+
+            str = sprintf('%s&nbsp;', htmlEntity);
         end
     end
 end

--- a/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/Progress.m
+++ b/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/Progress.m
@@ -77,6 +77,64 @@ classdef Progress < nansen.metadata.abstract.TableVariable & nansen.metadata.abs
                     '</HTML>'], hexColorDark.(mode), str1, hexColorLight.(mode), str2);
             end
         end
+
+        function progressBarString = getCellDisplayStringForContext(obj, displayContext)
+            if nargin < 2 || isempty(displayContext)
+                displayContext = "legacy";
+            end
+
+            if strcmpi(string(displayContext), "modern")
+                progressBarString = obj.getModernCellDisplayString();
+            else
+                progressBarString = obj.getCellDisplayString();
+            end
+        end
+
+        function progressBarString = getModernCellDisplayString(obj)
+        %getModernCellDisplayString Format progress using HTML block glyphs.
+
+            persistent hexColorDark hexColorLight
+
+            if isempty(hexColorDark) || isempty(hexColorLight)
+                [hexColorLight, hexColorDark] = obj.getProgressBarColors();
+            end
+
+            progressBarString = cell(1, numel(obj));
+
+            for i = 1:numel(obj)
+
+                if isstruct(obj(i).Value) && isfield(obj(i).Value, 'TaskList')
+                    thisTaskList = obj(i).Value.TaskList;
+                else
+                    progressBarString{i} = 'N/A'; continue
+                end
+
+                if isstruct(thisTaskList) && isfield(thisTaskList, 'IsFinished')
+                    isDone = [ thisTaskList.IsFinished ] ;
+                    mode = 'Standard';
+                else
+                    progressBarString{i} = 'N/A'; continue
+                end
+
+                pctProgress = mean(isDone);
+                if isnan(pctProgress)
+                    pctProgress = 0;
+                end
+
+                nSegments = 20;
+                nDone = ceil(nSegments * pctProgress);
+                nRemaining = nSegments - nDone;
+
+                doneStr = repmat('&#9608;', 1, nDone);
+                remainingStr = repmat('&#9608;', 1, nRemaining);
+
+                progressBarString{i} = sprintf(['<html>', ...
+                    '<font color="%s">%s</font>', ...
+                    '<font color="%s">%s</font>'], ...
+                    hexColorDark.(mode), doneStr, ...
+                    hexColorLight.(mode), remainingStr);
+            end
+        end
         
         function progressTooltipString = getCellTooltipString(obj)
             

--- a/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/Time.m
+++ b/code/modules/+nansen/+module/+general/+core/+tablevariable/+session/Time.m
@@ -26,7 +26,11 @@ classdef Time < nansen.metadata.abstract.TableVariable & nansen.metadata.abstrac
                 dtVector = [obj.Value];
                 dtVector.Format = obj.TimeFormat;
                 dtChar = char(dtVector);
-                dtChar = [repmat( sprintf('\t\t'), numel(obj), 1) , dtChar];
+                if ~nansen.util.useModernUiTable()
+                    % Java column content is tight when adjacent columns use
+                    % different alignment, so legacy tables keep tab padding.
+                    dtChar = [repmat( sprintf('\t\t'), numel(obj), 1) , dtChar];
+                end
                 str = mat2cell(dtChar, ones(numel(obj),1), size(dtChar,2) );
                 
             elseif isa(obj(1).Value, 'char')

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ fex://118460-file-downloader-uploader-with-progress-monitor
 fex://180185-matbox
 https://github.com/ehennestad/hierarchical-data-tree-matlab
 https://github.com/ehennestad/yamlmatlab
+https://github.com/ehennestad/entity-table


### PR DESCRIPTION

## Summary
Adds a MATLAB R2025a+ modern UI path for NANSEN metadata and file tables backed by EntityTable, while retaining the legacy Java/Widgets path for older MATLAB releases.

## What changed
- Adds release gates for modern UI components and table backends.
- Adds EntityTable dependency discovery and records `entity-table` in `requirements.txt`.
- Splits MetaTableViewer into modern EntityTable/uifigure and legacy Java backends.
- Adds modern and legacy file tree view implementations and routes NANSEN UI code through the selected backend.
- Moves Java warning, JavaFrame, drag-and-drop, and always-on-top behavior into legacy UI helpers.
- Updates session table renderers, layout persistence, filtering, and selection behavior for the modern backend.

## Manual test checklist
- [x] Launch NANSEN in MATLAB R2025b
- [x] Open the demo project session table and verify display, selection, sorting/filtering, ignored-entry toggling, and refresh behavior.
- [x] Change table layout settings and verify they persist after refresh/reopen.
- [x] Open FileViewer and verify the modern file tree renders and interacts correctly.
- [x] Exercise BatchProcessorUI and SessionTaskMenu interactions that depend on selected sessions.
- [x] Validate an older MATLAB release still follows the legacy Java/Widgets path, if available.
