### PR TITLE
Add content pixel position utility

### DIFF
--- a/code/+nansen/+ui/+widget/ButtonGroup.m
+++ b/code/+nansen/+ui/+widget/ButtonGroup.m
@@ -89,8 +89,8 @@ classdef ButtonGroup < handle
         end
 
         function updateLineHeight(obj, s, e)
-            parentHeight = getpixelposition( obj.Parent );
-            obj.Parent.UserData.Separator.Size(2) = parentHeight(4);
+            parentPosition = uim.utility.getContentPixelPosition(obj.Parent);
+            obj.Parent.UserData.Separator.Size(2) = parentPosition(4);
         end
     end
 
@@ -121,7 +121,7 @@ classdef ButtonGroup < handle
             obj.createToolbar()
             obj.createButtons()
 
-            panelPos = getpixelposition(obj.Parent);
+            panelPos = uim.utility.getContentPixelPosition(obj.Parent);
             
             linePos([1,3]) = floor([obj.Width, obj.Width]+2);
             linePos([2,4]) = [1, panelPos(4)];
@@ -219,6 +219,7 @@ classdef ButtonGroup < handle
     
         function onParentSizeChanged(obj, src, evt)
             obj.updateLineHeight()
+            obj.updateLocation()
         end
     end
 

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -1912,16 +1912,17 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                     end
                     
                     if isempty(app.UiFileViewer) % Create file viewer
-                    	thisTab = evt.NewValue;
+                        thisTab = evt.NewValue;
                         app.initializeFileViewer(thisTab)
                     end
-        
+
                     app.ActiveTabModule = app.UiFileViewer;
 
                     rowInd = app.UiMetaTableViewer.DisplayedRows;
                     sessionIDs = app.MetaTable.entries{rowInd, 'sessionID'};
                     app.UiFileViewer.SessionIDList = sessionIDs;
-                                        
+                    app.UiFileViewer.updateLayout()
+
                     selectedRows = app.UiMetaTableViewer.getSelectedEntries();
                     if isempty(selectedRows); return; end
                     
@@ -1969,6 +1970,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                         app.initializeBatchProcessorUI(evt.NewValue)
                     end
 
+                    app.BatchProcessorUI.updateLayout()
                     app.ActiveTabModule = app.BatchProcessorUI;
                 
                 otherwise
@@ -2068,7 +2070,13 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
 %             app.hLayout.TopBorder.Position(2) = 1-normalizedHeight;
 %             app.hLayout.TopBorder.Position(4) = normalizedHeight;
             
-            app.hLayout.TabGroup.Position = [10,6,figPosPix(3)-20,figPosPix(4)-30];
+            if nansen.util.useModernUiComponents()
+                mainPanelPosition = getpixelposition(app.hLayout.MainPanel);
+                app.hLayout.TabGroup.Position = [10, 6, ...
+                    mainPanelPosition(3)-20, mainPanelPosition(4)-12];
+            else
+                app.hLayout.TabGroup.Position = [10,6,figPosPix(3)-20,figPosPix(4)-30];
+            end
         end
         
     %%% Methods for updating statusfield (Q: Should this be a separate class?)

--- a/code/apps/+nansen/@FileViewer/FileViewer.m
+++ b/code/apps/+nansen/@FileViewer/FileViewer.m
@@ -167,6 +167,11 @@ classdef FileViewer < nansen.AbstractTabPageModule
                 drawnow
             end
         end
+
+        function updateLayout(obj)
+            drawnow limitrate
+            obj.updateComponentLayout()
+        end
     end
     
     methods % Set/get

--- a/code/apps/+nansen/BatchProcessorUI.m
+++ b/code/apps/+nansen/BatchProcessorUI.m
@@ -34,6 +34,9 @@ classdef BatchProcessorUI < handle
             obj.createUiTables()
                         
             obj.TabGroup.Visible = 'on';
+            drawnow
+            obj.UITableQueue.updateLayout()
+            obj.UITableHistory.updateLayout()
             
             % Call refresh table to update table contents
             obj.refreshTable('queue')
@@ -43,6 +46,12 @@ classdef BatchProcessorUI < handle
         
         function delete(obj)
             delete(obj.TabGroup)
+        end
+
+        function updateLayout(obj)
+            drawnow limitrate
+            obj.UITableQueue.updateLayout()
+            obj.UITableHistory.updateLayout()
         end
     end
     

--- a/code/apps/+nansen/uiwTaskTable.m
+++ b/code/apps/+nansen/uiwTaskTable.m
@@ -85,6 +85,10 @@ classdef uiwTaskTable < uiw.mixin.AssignPVPairs
         function selectedRows = get.selectedRows(obj)
             selectedRows = obj.Table.SelectedRows;
         end
+
+        function updateLayout(obj)
+            obj.updateTablePosition()
+        end
     end
     
     methods %Set/get
@@ -299,9 +303,11 @@ classdef uiwTaskTable < uiw.mixin.AssignPVPairs
         function updateTablePosition(obj)
                         
             MARGINS = [10, 10];
-            parentPos = getpixelposition(obj.Parent);
+            parentPos = uim.utility.getContentPixelPosition(obj.Parent);
 
-            newTablePosition = [MARGINS, parentPos(3:4) - MARGINS*2];
+            contentOrigin = max(parentPos(1:2), [1, 1]);
+            newTablePosition = [contentOrigin + MARGINS - 1, ...
+                parentPos(3:4) - MARGINS*2];
             obj.Table.Position = newTablePosition;
             
         end

--- a/code/graphics/+uim/+abstract/Component.m
+++ b/code/graphics/+uim/+abstract/Component.m
@@ -484,7 +484,7 @@ classdef Component < uim.handle & matlab.mixin.Heterogeneous & uim.mixin.assignP
             elseif isa(obj.Parent, 'uim.abstract.Component')
                 parentSize = obj.Parent.Position(3:4);
             elseif isa(obj.Parent, 'matlab.graphics.Graphics')
-                parentPosition = getpixelposition(obj.Parent);
+                parentPosition = uim.utility.getContentPixelPosition(obj.Parent);
                 parentSize = parentPosition(3:4);
 % %             elseif isa(obj.Parent, 'matlab.graphics.axis.Axes')
 % %                 parentSize = obj.Parent.Position(3:4);
@@ -552,7 +552,7 @@ classdef Component < uim.handle & matlab.mixin.Heterogeneous & uim.mixin.assignP
                 locationPoint = obj.Parent.getLocationPoint(obj.Location);
                 
             elseif obj.isMatlabGraphicsParent(obj.Parent)
-                parentPos = getpixelposition(obj.Parent);
+                parentPos = uim.utility.getContentPixelPosition(obj.Parent);
                 parentSize = parentPos(3:4);
                 locationPoint = obj.location2point(parentSize, obj.Location);
             else

--- a/code/graphics/+uim/+abstract/virtualContainer.m
+++ b/code/graphics/+uim/+abstract/virtualContainer.m
@@ -357,7 +357,7 @@ classdef virtualContainer < uim.handle & matlab.mixin.Heterogeneous
             elseif isa(obj.Parent, 'uim.abstract.virtualContainer')
                 parentSize = obj.Parent.Position(3:4);
             elseif isa(obj.Parent, 'matlab.graphics.Graphics')
-                parentPosition = getpixelposition(obj.Parent);
+                parentPosition = uim.utility.getContentPixelPosition(obj.Parent);
                 parentSize = parentPosition(3:4);
             elseif isa(obj.Parent, 'matlab.graphics.axis.Axes')
                 parentSize = obj.Parent.Position(3:4);
@@ -434,7 +434,7 @@ classdef virtualContainer < uim.handle & matlab.mixin.Heterogeneous
                 parentSize = obj.Parent.Size;
                 locationPoint = obj.Parent.getLocationPoint(obj.Location);
             elseif isa(obj.Parent, 'matlab.graphics.axis.Axes') || isa(obj.Parent, 'matlab.ui.Figure') || isa(obj.Parent, 'matlab.ui.container.Panel')
-                parentPos = getpixelposition(obj.Parent);
+                parentPos = uim.utility.getContentPixelPosition(obj.Parent);
                 parentSize = parentPos(3:4);
                 locationPoint = obj.location2point(parentSize, obj.Location);
             else

--- a/code/graphics/+uim/+utility/getContentPixelPosition.m
+++ b/code/graphics/+uim/+utility/getContentPixelPosition.m
@@ -1,0 +1,70 @@
+function pixelPosition = getContentPixelPosition(hParent)
+%getContentPixelPosition Return the drawable content area of a UI container.
+%
+%   For most containers, getpixelposition returns the usable content bounds.
+%   In web-based uifigure tabs, however, getpixelposition can include the tab
+%   header while normalized children are laid out below it. Measure that
+%   normalized child area explicitly so pixel-positioned children use the
+%   same bounds as normalized children.
+
+    pixelPosition = getpixelposition(hParent);
+
+    if ~isgraphics(hParent)
+        return
+    end
+
+    if ~isa(hParent, 'matlab.ui.container.Tab')
+        return
+    end
+
+    if ~isParentInUiFigure(hParent)
+        return
+    end
+
+    measuredPosition = measureNormalizedChildPosition(hParent);
+    if ~isempty(measuredPosition)
+        pixelPosition = measuredPosition;
+    end
+end
+
+function pixelPosition = measureNormalizedChildPosition(hParent)
+    pixelPosition = [];
+    hProbe = [];
+
+    try
+        hProbe = uipanel(hParent, ...
+            'Units', 'normalized', ...
+            'Position', [0, 0, 1, 1], ...
+            'BorderType', 'none', ...
+            'Visible', 'off', ...
+            'Tag', 'uimContentPixelPositionProbe');
+
+        drawnow limitrate
+        measuredPosition = getpixelposition(hProbe);
+
+        if all(measuredPosition(3:4) > 0)
+            pixelPosition = measuredPosition;
+        end
+    catch
+        pixelPosition = [];
+    end
+
+    if ~isempty(hProbe) && isvalid(hProbe)
+        delete(hProbe)
+    end
+end
+
+function tf = isParentInUiFigure(hParent)
+    tf = false;
+    hFigure = ancestor(hParent, 'figure');
+
+    if isempty(hFigure)
+        return
+    end
+
+    try
+        tf = matlab.ui.internal.isUIFigure(hFigure);
+    catch
+        tf = false;
+    end
+end

--- a/code/graphics/+uim/UIComponentCanvas.m
+++ b/code/graphics/+uim/UIComponentCanvas.m
@@ -240,7 +240,7 @@ classdef UIComponentCanvas < handle & uim.mixin.assignProperties % uix.Container
         
         function onSizeChanged(obj, ~, evt)
         %onSizeChanged Call an update to the PixelSize property
-            newParentPosition = getpixelposition(obj.Parent);
+            newParentPosition = uim.utility.getContentPixelPosition(obj.Parent);
             
             persistent t0
             if isempty(t0); t0 = clock; t0 = t0(6); end
@@ -266,7 +266,7 @@ classdef UIComponentCanvas < handle & uim.mixin.assignProperties % uix.Container
         function onLocationChanged(obj, ~, evt)
             
             obj.PreviousPixelPosition = obj.PixelPosition;
-            obj.PixelPosition = getpixelposition(obj.Parent);
+            obj.PixelPosition = uim.utility.getContentPixelPosition(obj.Parent);
 
         end
         
@@ -300,15 +300,20 @@ classdef UIComponentCanvas < handle & uim.mixin.assignProperties % uix.Container
 % %                 if ~all(isnan(obj.PreviousPixelPosition))
 % %                     obj.setAxesLimitsRelative()
 % %                 else
-                    newPosition = [1,1, obj.PixelSize];
+                    axesSize = max(obj.PixelSize, [1, 1]);
+                    axesLimits = [1, max(axesSize(1)+1, 2); ...
+                                  1, max(axesSize(2)+1, 2)];
+                    newPosition = [1,1, axesSize];
 
-                    set(obj.Axes, 'Position', newPosition, 'XLim', [1, obj.PixelSize(1)], 'YLim', [1, obj.PixelSize(2)])
+                    set(obj.Axes, 'Position', newPosition, ...
+                        'XLim', axesLimits(1, :), 'YLim', axesLimits(2, :))
 % %
 % %                 end
 
             else
-                obj.Axes.XLim = [1, obj.PixelSize(1)];
-                obj.Axes.YLim = [1, obj.PixelSize(2)];
+                axesSize = max(obj.PixelSize, [1, 1]);
+                obj.Axes.XLim = [1, max(axesSize(1)+1, 2)];
+                obj.Axes.YLim = [1, max(axesSize(2)+1, 2)];
             end
         end
         


### PR DESCRIPTION
## Summary

Adds `uim.utility.getContentPixelPosition`, a helper for reading the drawable content area of MATLAB graphics containers in pixel units.

Most containers can use `getpixelposition` directly. Tab containers are different: their reported pixel position can include tab chrome, while normalized children are laid out inside the content area below the tab header. When pixel-positioned controls use the outer bounds and normalized controls use the content bounds, layouts can drift, overlap, or leave controls partially hidden. This helper gives layout code one place to ask for the usable content rectangle.

## Changes

- Add `uim.utility.getContentPixelPosition`.
- Use content bounds in generic `uim` component/container layout code when deriving parent size or auto-location.
- Update `UIComponentCanvas` to use content bounds for parent size and location updates.
- Guard `UIComponentCanvas` axes limits against zero-sized parent measurements.
- Use content bounds when laying out tab-contained NANSEN controls, including the metadata table selector/table, batch-processor controls, task-table separators, and button groups.