### PR TITLE
Add menu modes for uifigure based app

### DIFF
--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -92,8 +92,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         % when selecting dynamic session task menu items.
         SessionTaskModeMenu matlab.ui.container.Menu
 
-        % SessionTaskModeSeparator - Separator between the task mode menu
-        % and dynamic task menus.
+        % SessionTaskModeSeparator - Separator between dynamic task menus
+        % and the task mode menu.
         SessionTaskModeSeparator matlab.ui.container.Menu
 
         % DiskConnectionMonitor - Monitors disk connections. This is used
@@ -459,9 +459,6 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
 
             uimenu(app.Figure, 'Text', '|', 'Enable', 'off'); % Separator
 
-            app.createMenu_SessionTaskMode()
-            app.createMenu_SessionTaskModeSeparator()
-
             app.SessionTaskMenu = nansen.SessionTaskMenu(app, app.CurrentProject, app.CurrentItemType);
             app.SessionTaskMenuUpdatedListener = addlistener(...
                 app.SessionTaskMenu, 'MenuUpdated', @app.onSessionTaskMenuUpdated);
@@ -470,6 +467,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             
             app.TaskInitializationListener = listener(...
                 app.SessionTaskMenu, 'MethodSelected', @app.onSessionTaskSelected);
+            app.createMenu_SessionTaskModeSeparator()
+            app.createMenu_SessionTaskMode()
             app.updateMenu_SessionTaskMode()
 
             % Create a help menu:
@@ -509,7 +508,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         end
 
         function createMenu_SessionTaskModeSeparator(app)
-        %createMenu_SessionTaskModeSeparator Create separator before tasks.
+        %createMenu_SessionTaskModeSeparator Create separator before mode.
 
             hMenu = findobj(app.Figure, 'Type', 'uimenu', '-and', ...
                 'Tag', 'core.session_task_mode.separator', '-depth', 1);
@@ -2112,11 +2111,14 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         end
         
         function onSessionTaskMenuUpdated(app, ~, ~)
-            % Need to recreate the Help menu in order for it to stay to the
-            % right of session task menus (uistack is not a good option,
-            % god knows why...)
+            % Recreate app-owned menus that should stay to the right of
+            % dynamic session task menus.
             uiMenuHelp = findobj(app.Figure, 'Type', 'uimenu',  '-and', '-regexp', 'Tag', 'Help', '-depth', 1);
             delete(uiMenuHelp)
+            delete(app.SessionTaskModeSeparator)
+            delete(app.SessionTaskModeMenu)
+            app.createMenu_SessionTaskModeSeparator()
+            app.createMenu_SessionTaskMode()
             app.createMenu_Help()
             app.updateMenu_SessionTaskMode()
         end

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -598,7 +598,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         end
 
         function wasHandled = setSessionTaskModeFromKey(app, keyName)
-        %setSessionTaskModeFromKey Set sticky task mode from a key press.
+        %setSessionTaskModeFromKey Toggle sticky task mode from a key press.
 
             wasHandled = false;
             keyName = char(string(keyName));
@@ -614,7 +614,12 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
 
             if isempty(matchIdx); return; end
 
-            app.setSessionTaskMode(modeInfo(matchIdx).Mode)
+            modeName = modeInfo(matchIdx).Mode;
+            if strcmp(app.getSessionTaskMode(), modeName)
+                app.setSessionTaskMode('Default')
+            else
+                app.setSessionTaskMode(modeName)
+            end
             wasHandled = true;
         end
 
@@ -2257,7 +2262,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             
             % Session task modes are sticky for compatibility with native
             % uifigure menus, which do not forward key events while open.
-            % Press Escape to return to default mode.
+            % Shortcut keys toggle modes, and Escape clears the mode.
         end
         
         function updateLayoutPositions(app)

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -92,6 +92,10 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         % when selecting dynamic session task menu items.
         SessionTaskModeMenu matlab.ui.container.Menu
 
+        % SessionTaskModeSeparator - Separator between the task mode menu
+        % and dynamic task menus.
+        SessionTaskModeSeparator matlab.ui.container.Menu
+
         % DiskConnectionMonitor - Monitors disk connections. This is used
         % for nansen to update states for data location indicators.
         DiskConnectionMonitor (1,1) nansen.internal.system.DiskConnectionMonitor
@@ -456,6 +460,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             uimenu(app.Figure, 'Text', '|', 'Enable', 'off'); % Separator
 
             app.createMenu_SessionTaskMode()
+            app.createMenu_SessionTaskModeSeparator()
 
             app.SessionTaskMenu = nansen.SessionTaskMenu(app, app.CurrentProject, app.CurrentItemType);
             app.SessionTaskMenuUpdatedListener = addlistener(...
@@ -501,6 +506,24 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             end
 
             app.updateMenu_SessionTaskMode()
+        end
+
+        function createMenu_SessionTaskModeSeparator(app)
+        %createMenu_SessionTaskModeSeparator Create separator before tasks.
+
+            hMenu = findobj(app.Figure, 'Type', 'uimenu', '-and', ...
+                'Tag', 'core.session_task_mode.separator', '-depth', 1);
+
+            if isempty(hMenu)
+                hMenu = uimenu(app.Figure, ...
+                    'Text', '|', ...
+                    'Enable', 'off', ...
+                    'Tag', 'core.session_task_mode.separator');
+            else
+                hMenu = hMenu(1);
+            end
+
+            app.SessionTaskModeSeparator = hMenu;
         end
 
         function updateMenu_SessionTaskMode(app)

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -88,6 +88,10 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         % set of session / items tasks on the main figure menu
         SessionTaskMenu nansen.SessionTaskMenu
 
+        % SessionTaskModeMenu - Top level menu for choosing the mode used
+        % when selecting dynamic session task menu items.
+        SessionTaskModeMenu matlab.ui.container.Menu
+
         % DiskConnectionMonitor - Monitors disk connections. This is used
         % for nansen to update states for data location indicators.
         DiskConnectionMonitor (1,1) nansen.internal.system.DiskConnectionMonitor
@@ -124,6 +128,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         % WindowKeyPressedListener event.listener
         TaskInitializationListener event.listener
         SessionTaskMenuUpdatedListener event.listener
+        SessionTaskMenuModeChangedListener event.listener
     end
 
     properties (Access = private) % Metatable listeners
@@ -388,7 +393,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             app.Figure.WindowKeyPressFcn = @app.onKeyPressed;
             app.Figure.WindowKeyReleaseFcn = @app.onKeyReleased;
             
-            if nansen.util.isJavaFrameSupported
+            if nansen.util.isJavaFrameSupported()
                 warnCleanup = nansen.ui.legacy.tempDisableJavaFrameWarnings(); %#ok<NASGU>
                 [~, hJ] = evalc('findjobj(app.Figure)');
                 hJ(2).KeyPressedCallback = @app.onKeyPressed;
@@ -450,17 +455,145 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
 
             uimenu(app.Figure, 'Text', '|', 'Enable', 'off'); % Separator
 
+            app.createMenu_SessionTaskMode()
+
             app.SessionTaskMenu = nansen.SessionTaskMenu(app, app.CurrentProject, app.CurrentItemType);
             app.SessionTaskMenuUpdatedListener = addlistener(...
                 app.SessionTaskMenu, 'MenuUpdated', @app.onSessionTaskMenuUpdated);
+            app.SessionTaskMenuModeChangedListener = addlistener(...
+                app.SessionTaskMenu, 'ModeChanged', @app.onSessionTaskModeChanged);
             
             app.TaskInitializationListener = listener(...
                 app.SessionTaskMenu, 'MethodSelected', @app.onSessionTaskSelected);
+            app.updateMenu_SessionTaskMode()
 
             % Create a help menu:
             app.createMenu_Help()
             
             % app.createMenu_Figure() - Not implemented
+        end
+
+        function createMenu_SessionTaskMode(app)
+        %createMenu_SessionTaskMode Create menu for selecting task mode.
+
+            hMenu = findobj(app.Figure, 'Type', 'uimenu', '-and', ...
+                'Tag', 'core.session_task_mode', '-depth', 1);
+
+            if isempty(hMenu)
+                hMenu = uimenu(app.Figure, ...
+                    'Text', 'Mode (Default)', ...
+                    'Tag', 'core.session_task_mode');
+            else
+                hMenu = hMenu(1);
+                delete(hMenu.Children)
+            end
+
+            app.SessionTaskModeMenu = hMenu;
+
+            modeInfo = app.getSessionTaskModeInfo();
+            for i = 1:numel(modeInfo)
+                modeValue = modeInfo(i).Mode;
+                mitem = uimenu(hMenu, ...
+                    'Text', modeInfo(i).MenuText, ...
+                    'Tag', sprintf('core.session_task_mode.%s', lower(modeValue)), ...
+                    'UserData', modeValue);
+                mitem.MenuSelectedFcn = @(~, ~) app.setSessionTaskMode(modeValue);
+            end
+
+            app.updateMenu_SessionTaskMode()
+        end
+
+        function updateMenu_SessionTaskMode(app)
+        %updateMenu_SessionTaskMode Update checked mode and top label.
+
+            hMenu = app.SessionTaskModeMenu;
+            if isempty(hMenu) || ~isvalid(hMenu)
+                hMenu = findobj(app.Figure, 'Type', 'uimenu', '-and', ...
+                    'Tag', 'core.session_task_mode', '-depth', 1);
+                if isempty(hMenu); return; end
+                hMenu = hMenu(1);
+                app.SessionTaskModeMenu = hMenu;
+            end
+
+            currentMode = app.getSessionTaskMode();
+            hMenu.Text = sprintf('Mode (%s)', ...
+                app.getSessionTaskModeLabel(currentMode));
+
+            for i = 1:numel(hMenu.Children)
+                if strcmp(hMenu.Children(i).UserData, currentMode)
+                    hMenu.Children(i).Checked = 'on';
+                else
+                    hMenu.Children(i).Checked = 'off';
+                end
+            end
+        end
+
+        function setSessionTaskMode(app, modeName)
+        %setSessionTaskMode Set mode used by dynamic session task menus.
+
+            if isempty(app.SessionTaskMenu) || ~isvalid(app.SessionTaskMenu)
+                app.updateMenu_SessionTaskMode()
+                return
+            end
+
+            app.SessionTaskMenu.Mode = modeName;
+            app.updateMenu_SessionTaskMode()
+        end
+
+        function modeName = getSessionTaskMode(app)
+        %getSessionTaskMode Get current dynamic session task menu mode.
+
+            if isempty(app.SessionTaskMenu) || ~isvalid(app.SessionTaskMenu)
+                modeName = 'Default';
+            else
+                modeName = app.SessionTaskMenu.Mode;
+            end
+        end
+
+        function label = getSessionTaskModeLabel(app, modeName)
+        %getSessionTaskModeLabel Get display label for a task mode.
+
+            modeInfo = app.getSessionTaskModeInfo();
+            modeNames = {modeInfo.Mode};
+            matchIdx = find(strcmp(modeNames, modeName), 1, 'first');
+
+            if isempty(matchIdx)
+                label = modeName;
+            else
+                label = modeInfo(matchIdx).Label;
+            end
+        end
+
+        function modeInfo = getSessionTaskModeInfo(app) %#ok<MANU>
+        %getSessionTaskModeInfo Definitions for task mode menu/key map.
+
+            modeInfo = struct( ...
+                'Mode', {'Default', 'Preview', 'TaskQueue', 'Edit', 'Restart', 'Help'}, ...
+                'Label', {'Default', 'Preview', 'Queue', 'Edit', 'Restart', 'Help'}, ...
+                'MenuText', {'Default (Esc)', 'Preview (Shift)', 'Queue (q)', ...
+                    'Edit (e)', 'Restart (r)', 'Help (h)'}, ...
+                'Key', {'escape', 'shift', 'q', 'e', 'r', 'h'} );
+        end
+
+        function wasHandled = setSessionTaskModeFromKey(app, keyName)
+        %setSessionTaskModeFromKey Set sticky task mode from a key press.
+
+            wasHandled = false;
+            keyName = char(string(keyName));
+            if numel(keyName) == 1 && double(keyName) == 27
+                keyName = 'escape';
+            else
+                keyName = lower(keyName);
+            end
+
+            modeInfo = app.getSessionTaskModeInfo();
+            keyNames = {modeInfo.Key};
+            matchIdx = find(strcmp(keyNames, keyName), 1, 'first');
+
+            if isempty(matchIdx); return; end
+
+            app.setSessionTaskMode(modeInfo(matchIdx).Mode)
+            wasHandled = true;
         end
 
         function createMenu_Nansen(app, hMenu)
@@ -1962,6 +2095,11 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             uiMenuHelp = findobj(app.Figure, 'Type', 'uimenu',  '-and', '-regexp', 'Tag', 'Help', '-depth', 1);
             delete(uiMenuHelp)
             app.createMenu_Help()
+            app.updateMenu_SessionTaskMode()
+        end
+
+        function onSessionTaskModeChanged(app, ~, ~)
+            app.updateMenu_SessionTaskMode()
         end
 
         function onTabChanged(app, ~, evt)
@@ -2076,32 +2214,11 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                 end
             end
             
+            if app.setSessionTaskModeFromKey(evt.Key)
+                return
+            end
+
             switch evt.Key
-        
-                case {'shift', 'q', 'e', 'r', 'h'}
-
-% % %                     timeSinceLastPress = toc(lastKeyPressTime);
-% % %                     timeSinceLastPress
-% % %                     if timeSinceLastPress < 0.1
-% % %                         lastKeyPressTime = tic;
-% % %                         return;
-% % %                     end
-
-                    switch evt.Key
-                        case 'shift'
-                            app.SessionTaskMenu.Mode = 'Preview';
-                        case 'q'
-                            app.SessionTaskMenu.Mode = 'TaskQueue';
-                        case 'e'
-                            app.SessionTaskMenu.Mode = 'Edit';
-                        case 'r'
-                            app.SessionTaskMenu.Mode = 'Restart';
-                        case 'h'
-                            app.SessionTaskMenu.Mode = 'Help';
-                    end
-
-% % %                     lastKeyPressTime = tic;
-
                 case 'w'
                     app.sendToWorkspace()
             end
@@ -2113,10 +2230,9 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                 evt = uim.event.javaKeyEventToMatlabKeyData(evt);
             end
             
-            switch evt.Key
-                case {'shift', 'q', 'e', 'r', 'h'}
-                    app.SessionTaskMenu.Mode = 'Default';
-            end
+            % Session task modes are sticky for compatibility with native
+            % uifigure menus, which do not forward key events while open.
+            % Press Escape to return to default mode.
         end
         
         function updateLayoutPositions(app)

--- a/code/apps/+nansen/SessionTaskMenu.m
+++ b/code/apps/+nansen/SessionTaskMenu.m
@@ -86,6 +86,7 @@ classdef SessionTaskMenu < handle
     end
     
     events
+        ModeChanged
         MenuUpdated
         MethodSelected
     end
@@ -156,6 +157,7 @@ classdef SessionTaskMenu < handle
             if ~isequal(newMode, obj.Mode)
                 obj.Mode = newMode;
                 obj.refreshMenuLabels()
+                obj.notify('ModeChanged', event.EventData)
             end
         end
                
@@ -203,6 +205,7 @@ classdef SessionTaskMenu < handle
             
             obj.SessionTasks = struct('Name', {}, 'Attributes', {});
             obj.buildMenuFromDirectory(obj.ParentApp.Figure);
+            obj.refreshMenuLabels()
 
             obj.notify('MenuUpdated', event.EventData)
         end

--- a/code/examples/uifigure_menu_mode_demo.m
+++ b/code/examples/uifigure_menu_mode_demo.m
@@ -1,0 +1,243 @@
+function uifigure_menu_mode_demo()
+%UIFIGURE_MENU_MODE_DEMO Demonstrate live menu modes with uifigure key callbacks.
+%
+% Run:
+%   uifigure_menu_mode_demo
+%
+% Select a sticky mode using the toolbar or these keys:
+%   Shift  : Preview
+%   q      : Queue
+%   e      : Edit
+%   r      : Restart
+%   h      : Help
+%   Escape : Default
+
+    iconButtonFolder = [ ...
+        '/Users/eivihe/Code/MATLAB/General/FEX/icon_button_component', ...
+        '/icon_button_component'];
+    if exist(iconButtonFolder, 'dir')
+        addpath(iconButtonFolder)
+    else
+        error('Could not find IconButton folder: %s', iconButtonFolder)
+    end
+
+    mode = "Default";
+    modeNames = ["Default", "Preview", "Queue", "Edit", "Restart", "Help"];
+    modeKeys = ["escape", "shift", "q", "e", "r", "h"];
+
+    fig = uifigure( ...
+        "Name", "uifigure Menu Mode Demo", ...
+        "Position", [100 100 560 380]);
+
+    fig.WindowKeyPressFcn = @onKeyPressed;
+
+    layout = uigridlayout(fig, [3 1]);
+    layout.RowHeight = {25, 28, "1x"};
+    layout.ColumnWidth = {"1x"};
+    layout.Padding = [16 16 0 0];
+    layout.RowSpacing = 8;
+
+    header = uigridlayout(layout, [1 2]);
+    header.Layout.Row = 1;
+    header.ColumnWidth = {"1x", numel(modeNames)*25};
+    header.RowHeight = {25};
+    header.Padding = [0 0 0 0];
+    header.ColumnSpacing = 0;
+
+    toolbar = uigridlayout(header, [1 numel(modeNames)]);
+    toolbar.Layout.Row = 1;
+    toolbar.Layout.Column = 2;
+    toolbar.ColumnWidth = repmat({25}, 1, numel(modeNames));
+    toolbar.RowHeight = {25};
+    toolbar.Padding = [0 0 0 0];
+    toolbar.ColumnSpacing = 0;
+
+    statusLabel = uilabel(layout, ...
+        "Text", "Mode: Default. Press q/e/r/h/Shift or use toolbar; Escape resets.");
+    statusLabel.Layout.Row = 2;
+
+    logArea = uitextarea(layout, ...
+        "Editable", "off", ...
+        "Value", {'Selected commands are logged here.'});
+    logArea.Layout.Row = 3;
+
+    sessionMenu = uimenu(fig, "Text", "&Session");
+    taskItems = matlab.ui.container.Menu.empty(0, 1);
+    taskItems(end+1) = addTaskMenuItem(sessionMenu, "Load Data", true);
+    taskItems(end+1) = addTaskMenuItem(sessionMenu, "Motion Correct", true);
+    taskItems(end+1) = addTaskMenuItem(sessionMenu, "Manual Curation", false);
+    taskItems(end+1) = addTaskMenuItem(sessionMenu, "Plot Summary", false);
+
+    modeMenu = uimenu(fig, "Text", "&Mode");
+    modeItems = matlab.ui.container.Menu.empty(0, 1);
+    modeItems(end+1) = addModeMenuItem(modeMenu, "Default");
+    modeItems(end+1) = addModeMenuItem(modeMenu, "Preview");
+    modeItems(end+1) = addModeMenuItem(modeMenu, "Queue");
+    modeItems(end+1) = addModeMenuItem(modeMenu, "Edit");
+    modeItems(end+1) = addModeMenuItem(modeMenu, "Restart");
+    modeItems(end+1) = addModeMenuItem(modeMenu, "Help");
+
+    modeButtons = IconButton.empty(0, 1);
+    iconMap = getModeIconMap(iconButtonFolder);
+    for i = 1:numel(modeNames)
+        modeButtons(end+1) = addModeToolbarButton( ...
+            toolbar, modeNames(i), modeKeys(i), iconMap.(char(modeNames(i))));
+        modeButtons(end).Layout.Row = 1;
+        modeButtons(end).Layout.Column = i;
+    end
+
+    updateMenus()
+
+    function item = addTaskMenuItem(parent, label, isQueueable)
+        item = uimenu(parent, ...
+            "Text", label, ...
+            "MenuSelectedFcn", @onTaskMenuSelected);
+
+        item.UserData = struct( ...
+            'BaseText', label, ...
+            'IsQueueable', isQueueable);
+    end
+
+    function item = addModeMenuItem(parent, label)
+        item = uimenu(parent, ...
+            "Text", label, ...
+            "MenuSelectedFcn", @(~, ~) setMode(label));
+    end
+
+    function button = addModeToolbarButton(parent, label, keyName, svgPath)
+        button = IconButton(parent, ...
+            "SVGSource", svgPath, ...
+            "Width", 25, ...
+            "Height", 25, ...
+            "Padding", 3, ...
+            "CornerRadius", 3, ...
+            "BackgroundAlpha_Hover", 0.3);
+        button.Tooltip = sprintf('%s (%s)', char(label), char(keyName));
+        button.UserData = label;
+        button.ButtonPushedFcn = @onModeButtonPushed;
+    end
+
+    function onKeyPressed(~, event)
+        switch string(event.Key)
+            case "escape"
+                setMode("Default")
+            case "shift"
+                setMode("Preview")
+            case "q"
+                setMode("Queue")
+            case "e"
+                setMode("Edit")
+            case "r"
+                setMode("Restart")
+            case "h"
+                setMode("Help")
+        end
+    end
+
+    function onModeButtonPushed(src, ~)
+        selectedMode = string(src.UserData);
+        if selectedMode == mode && selectedMode ~= "Default"
+            setMode("Default")
+        else
+            setMode(selectedMode)
+        end
+        refocusFigure()
+    end
+
+    function setMode(newMode)
+        newMode = string(newMode);
+        if mode == newMode
+            return
+        end
+
+        mode = newMode;
+        updateMenus()
+    end
+
+    function updateMenus()
+        statusLabel.Text = "Mode: " + mode ...
+            + ". Press q/e/r/h/Shift or use toolbar; Escape resets.";
+
+        for i = 1:numel(taskItems)
+            item = taskItems(i);
+            data = item.UserData;
+
+            item.Text = data.BaseText + modeSuffix(mode);
+            item.Enable = "on";
+
+            if mode == "Queue" && ~data.IsQueueable
+                item.Enable = "off";
+            end
+        end
+
+        for i = 1:numel(modeItems)
+            if string(modeItems(i).Text) == mode
+                modeItems(i).Checked = "on";
+            else
+                modeItems(i).Checked = "off";
+            end
+        end
+
+        for i = 1:numel(modeButtons)
+            buttonMode = string(modeButtons(i).UserData);
+            if buttonMode == mode
+                modeButtons(i).Color = "#0072BD";
+                modeButtons(i).BackgroundColor = [0.86 0.93 0.98];
+            else
+                modeButtons(i).Color = "#5F6368";
+                modeButtons(i).BackgroundColor = [0.94 0.94 0.94];
+            end
+        end
+        modeItems(1).Parent.Text = sprintf("Mode (%s)", mode);
+    end
+
+    function suffix = modeSuffix(currentMode)
+        switch currentMode
+            case "Default"
+                suffix = "";
+            case "Preview"
+                suffix = " ...";
+            case "Queue"
+                suffix = " (q)";
+            case "Edit"
+                suffix = " (e)";
+            case "Restart"
+                suffix = " (r)";
+            case "Help"
+                suffix = " (h)";
+            otherwise
+                suffix = "";
+        end
+    end
+
+    function onTaskMenuSelected(src, ~)
+        data = src.UserData;
+        newEntry = sprintf('%s selected in %s mode', ...
+            char(data.BaseText), char(mode));
+        logArea.Value = [{newEntry}; logArea.Value(:)];
+
+        setMode("Default")
+        refocusFigure()
+    end
+
+    function refocusFigure()
+        try
+            focus(fig)
+        catch
+            % focus is available only for some UI targets/MATLAB releases.
+        end
+    end
+
+    function iconMap = getModeIconMap(componentFolder)
+        iconFolder = fullfile(componentFolder, 'resources', 'icons');
+        bicolorFolder = fullfile(iconFolder, 'bicolor');
+
+        iconMap = struct();
+        iconMap.Default = fullfile(bicolorFolder, '001_-home-page.svg');
+        iconMap.Preview = fullfile(bicolorFolder, '001_-search.svg');
+        iconMap.Queue = fullfile(bicolorFolder, '001_-forward.svg');
+        iconMap.Edit = fullfile(bicolorFolder, '001_-detail-page.svg');
+        iconMap.Restart = fullfile(iconFolder, 'play-113.svg');
+        iconMap.Help = fullfile(bicolorFolder, '001_-information.svg');
+    end
+end

--- a/code/graphics/+uim/+event/javaKeyEventToMatlabKeyData.m
+++ b/code/graphics/+uim/+event/javaKeyEventToMatlabKeyData.m
@@ -64,6 +64,8 @@ function keyName = getSpecialKey(jEvt)
     switch keyCode
         case 16
             keyName = 'shift';
+        case 27
+            keyName = 'escape';
         case 17
             keyName = 'control';
         case 18

--- a/code/resources/docs/nansen_app/keyboard_shortcuts.html
+++ b/code/resources/docs/nansen_app/keyboard_shortcuts.html
@@ -3,11 +3,13 @@
 <li><strong>w</strong> : Send selected session objects to workspace</li>
 </ul>
 <h3 id="menu-options-session-methods-">Menu options (session methods):</h3>
-<p>There are different modes available for each of the session methods in the menus. To activate a mode, press and hold one of the keys in the list below. When the key is pressed, a symbol should appear next to the name of the method. For example, when pressing and holding the shift button, an ellipsis (...) should appear next to each session method in the menu. The following modes are currently available:</p>
+<p>There are different modes available for each of the session methods in the menus. To activate a mode, select it from the Mode menu or press one of the keys in the list below. The selected mode remains active until a method is selected or Escape is pressed. When a mode is active, a symbol should appear next to the name of the method. For example, when selecting Preview mode, an ellipsis (...) should appear next to each session method in the menu. The following modes are currently available:</p>
 <ul>
 <li><strong>shift</strong> : Open the options for that session method</li>
 <li><strong>q</strong> : Add the method to the task processor [q]ueue</li>
 <li><strong>e</strong> : Open (and [e]dit) the m-file for the session method</li>
+<li><strong>r</strong> : Restart a previously run session method</li>
 <li><strong>h</strong> : Open a help dialog with description/help for the session method</li>
+<li><strong>escape</strong> : Return to the default mode</li>
 </ul>
-<p>Note: These modes are not working when using nansen through a remote connection, like teamviewer.</p>
+<p>Note: These modes require keyboard focus in the NANSEN window. Use the Mode menu if keyboard shortcuts are unavailable, for example when using nansen through a remote connection like teamviewer.</p>


### PR DESCRIPTION
## Summary
Figures created with `uifigure` does not trigger keyboard callbacks when figure menus are open. Therefore the old session task menu modes cannot be switched while viewing a menu in a modern uifigure.

## What's changed

- Added a menu item on Nansen's main menu for switching menu modes. Can be used for switching modes instead of using key shortcuts.
- Key strokes now toggle the mode on press. Press once activates the mode. Press a second time (or press escape) deactivates the mode.
- For old figures created with `figure` on MATLAB R2024b or earlier (figures backed by javaframe), keys can still be used to change menu mode when the menus are open, but the press and hold behaviour is now press once to activate, press twice to deactivate