### PR TITLE
[codex] Use modern message dialogs

### DIFF
--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -153,6 +153,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             app@uiw.abstract.AppWindow('Preferences', nansen.Preferences, 'Visible', 'off')
             
             setappdata(app.Figure, 'AppInstance', app)
+            app.MessageDisplay = nansen.MessageDisplay(app.Figure);
             
             [isAppOpen, hApp] = app.isOpen();
             if isAppOpen
@@ -1810,7 +1811,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         function onProjectChanged(app, varargin)
             app.TableIsUpdating = true;
             returnToIdle = app.setBusy('Changing project'); %#ok<NASGU>
-            hDlg = app.MessageDisplay.inform('Please wait, changing project...');
+            hDlg = app.MessageDisplay.wait('Please wait, changing project...', ...
+                'Title', 'Changing Project');
             
             app.BatchProcessor.closeTaskList()
 
@@ -2878,7 +2880,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             numSessions = numel(metaObjects);
             
             if numSessions > 5 && ~reset
-                h = waitbar(0, 'Please wait while updating values');
+                h = app.MessageDisplay.wait('Please wait while updating values', ...
+                    'Title', 'Updating Values');
                 waitbarCleanup = onCleanup(@() delete(h));
             end
             
@@ -2951,7 +2954,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
                     end
 
                     if numSessions > 5
-                        waitbar(iSession/numSessions, h)
+                        app.MessageDisplay.updateProgress(h, iSession/numSessions)
                     end
                 end
             end
@@ -3127,7 +3130,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         
         function refreshTable(app)
             returnToIdle = app.setBusy('Updating table'); %#ok<NASGU>
-            hDlg = app.MessageDisplay.inform('Please wait, updating table...');
+            hDlg = app.MessageDisplay.wait('Please wait, updating table...', ...
+                'Title', 'Updating Table');
             resetView = false;
             app.UiMetaTableViewer.resetTable(resetView)
             app.onNewMetaTableSet()

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -2882,7 +2882,7 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             if numSessions > 5 && ~reset
                 h = app.MessageDisplay.wait('Please wait while updating values', ...
                     'Title', 'Updating Values');
-                waitbarCleanup = onCleanup(@() delete(h));
+                waitbarCleanup = onCleanup(@() ~isempty(h) && isvalid(h) && delete(h));
             end
             
             % Todo: This function call is different for preprogrammed

--- a/code/apps/+nansen/@App/App.m
+++ b/code/apps/+nansen/@App/App.m
@@ -1811,8 +1811,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
         function onProjectChanged(app, varargin)
             app.TableIsUpdating = true;
             returnToIdle = app.setBusy('Changing project'); %#ok<NASGU>
-            hDlg = app.MessageDisplay.wait('Please wait, changing project...', ...
-                'Title', 'Changing Project');
+            [hDlg, dlgCleanup] = app.MessageDisplay.wait('Please wait, changing project...', ...
+                'Title', 'Changing Project'); %#ok<ASGLU>
             
             app.BatchProcessor.closeTaskList()
 
@@ -1895,7 +1895,6 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             end
 
             app.TableIsUpdating = false;
-            delete(hDlg)
             clear returnToIdle
         end
         
@@ -2880,9 +2879,8 @@ classdef App < uiw.abstract.AppWindow & nansen.mixin.UserSettings & ...
             numSessions = numel(metaObjects);
             
             if numSessions > 5 && ~reset
-                h = app.MessageDisplay.wait('Please wait while updating values', ...
-                    'Title', 'Updating Values');
-                waitbarCleanup = onCleanup(@() ~isempty(h) && isvalid(h) && delete(h));
+                [h, waitbarCleanup] = app.MessageDisplay.wait('Please wait while updating values', ...
+                    'Title', 'Updating Values'); %#ok<ASGLU>
             end
             
             % Todo: This function call is different for preprogrammed

--- a/code/apps/+nansen/@MessageDisplay/MessageDisplay.m
+++ b/code/apps/+nansen/@MessageDisplay/MessageDisplay.m
@@ -119,7 +119,7 @@ classdef MessageDisplay < handle
             end
         end
 
-        function hDialog = wait(obj, message, options)
+        function [hDialog, dialogCleanupObj] = wait(obj, message, options)
         % wait - Open an indeterminate progress dialog.
 
             arguments
@@ -138,6 +138,10 @@ classdef MessageDisplay < handle
                     'Indeterminate', char(options.Indeterminate));
             else
                 hDialog = waitbar(options.Value, message);
+            end
+
+            if nargout == 2
+                dialogCleanupObj = onCleanup(@()deleteWaitbarIfValid(hDialog));
             end
         end
 
@@ -254,5 +258,11 @@ classdef MessageDisplay < handle
             end
             cancelOption = char(alternatives(cancelIdx));
         end
+    end
+end
+
+function deleteWaitbarIfValid(waitbarHandle)
+    if ~isempty(waitbarHandle) && isvalid(waitbarHandle)
+        delete(waitbarHandle)
     end
 end

--- a/code/apps/+nansen/@MessageDisplay/MessageDisplay.m
+++ b/code/apps/+nansen/@MessageDisplay/MessageDisplay.m
@@ -1,8 +1,8 @@
 classdef MessageDisplay < handle
 % MessageDisplay - Class interface for displaying messages to user.
 
-    properties (SetAccess = private) % Or immutable?
-        App % Placeholder for now
+    properties (SetAccess = protected) % Or immutable?
+        App = [] % Owning app or figure used for parented modern dialogs.
     end
 
     properties % Preferences
@@ -10,6 +10,14 @@ classdef MessageDisplay < handle
     end
 
     methods
+        function obj = MessageDisplay(app)
+            arguments
+                app = []
+            end
+
+            obj.App = app;
+        end
+
         function hFigure = inform(obj, message, options)
         % inform - Open a message box with info message
             
@@ -21,9 +29,16 @@ classdef MessageDisplay < handle
             end
 
             messageStr = obj.getFormattedMessage(message);
-            opts = obj.getDialogOptions();
-            
-            hFigure = msgbox(messageStr, options.Title, opts);
+            hFigure = [];
+
+            if obj.useModernDialog("uialert")
+                uialert(obj.getDialogParent(), message, options.Title, ...
+                    'Icon', obj.getAlertIcon(options.Icon, "info"))
+            else
+                opts = obj.getDialogOptions();
+                hFigure = msgbox(messageStr, options.Title, opts);
+            end
+
             if ~nargout
                 clear hFigure
             end
@@ -46,11 +61,22 @@ classdef MessageDisplay < handle
             if any( strcmp(options.Alternatives, options.DefaultAnswer) )
                 defaultAnswer = char(options.DefaultAnswer);
             else
-                defaultAnswer = options.Alternatives{1};
+                defaultAnswer = char(options.Alternatives(1));
             end
-            dlgOptions.Default = defaultAnswer;
-            answer = questdlg(promptStr, options.Title, ...
-                options.Alternatives{:}, dlgOptions);
+
+            if obj.useModernDialog("uiconfirm")
+                cancelOption = obj.getCancelOption(options.Alternatives);
+                answer = uiconfirm(obj.getDialogParent(), question, options.Title, ...
+                    'Options', cellstr(options.Alternatives), ...
+                    'DefaultOption', defaultAnswer, ...
+                    'CancelOption', cancelOption, ...
+                    'Icon', 'question');
+                answer = char(answer);
+            else
+                dlgOptions.Default = defaultAnswer;
+                answer = questdlg(promptStr, options.Title, ...
+                    options.Alternatives{:}, dlgOptions);
+            end
         end
 
         function warn(obj, message, options)
@@ -63,9 +89,14 @@ classdef MessageDisplay < handle
             end
 
             messageStr = obj.getFormattedMessage(message);
-            opts = obj.getDialogOptions();
-            
-            warndlg(messageStr, options.Title, opts)
+
+            if obj.useModernDialog("uialert")
+                uialert(obj.getDialogParent(), message, options.Title, ...
+                    'Icon', 'warning')
+            else
+                opts = obj.getDialogOptions();
+                warndlg(messageStr, options.Title, opts)
+            end
         end
 
         function alert(obj, message, options)
@@ -78,13 +109,64 @@ classdef MessageDisplay < handle
             end
             
             messageStr = obj.getFormattedMessage(message);
-            opts = obj.getDialogOptions();
-            
-            errordlg(messageStr, options.Title, opts)
+
+            if obj.useModernDialog("uialert")
+                uialert(obj.getDialogParent(), message, options.Title, ...
+                    'Icon', 'error')
+            else
+                opts = obj.getDialogOptions();
+                errordlg(messageStr, options.Title, opts)
+            end
         end
 
-        function wait(obj) %#ok<MANU>
-            % Not implemented yet
+        function hDialog = wait(obj, message, options)
+        % wait - Open an indeterminate progress dialog.
+
+            arguments
+                obj (1,1) nansen.MessageDisplay
+                message (1,1) string = "Please wait..."
+                options.Title (1,1) string = "Please Wait"
+                options.Value (1,1) double {mustBeGreaterThanOrEqual(options.Value, 0), mustBeLessThanOrEqual(options.Value, 1)} = 0
+                options.Indeterminate (1,1) matlab.lang.OnOffSwitchState = "on"
+            end
+
+            if obj.useModernDialog("uiprogressdlg")
+                hDialog = uiprogressdlg(obj.getDialogParent(), ...
+                    'Title', options.Title, ...
+                    'Message', message, ...
+                    'Value', options.Value, ...
+                    'Indeterminate', char(options.Indeterminate));
+            else
+                hDialog = waitbar(options.Value, message);
+            end
+        end
+
+        function updateProgress(~, hDialog, value, message)
+        % updateProgress - Update progress dialog value and optional message.
+
+            arguments
+                ~
+                hDialog
+                value (1,1) double {mustBeGreaterThanOrEqual(value, 0), mustBeLessThanOrEqual(value, 1)}
+                message (1,1) string = string(missing)
+            end
+
+            if isempty(hDialog) || ~isvalid(hDialog)
+                return
+            end
+
+            if isprop(hDialog, 'Value')
+                hDialog.Value = value;
+                if ~ismissing(message) && isprop(hDialog, 'Message')
+                    hDialog.Message = message;
+                end
+            else
+                if ismissing(message)
+                    waitbar(value, hDialog)
+                else
+                    waitbar(value, hDialog, message)
+                end
+            end
         end
     end
 
@@ -94,7 +176,7 @@ classdef MessageDisplay < handle
         end
 
         function formattedMessage = getFormattedMessage(obj, message)
-            if nansen.util.isJavaFrameSupported()
+            if ~obj.useModernDialog("uialert") && nansen.util.isJavaFrameSupported()
                 % For javaframe backed figures, the fontsize of modal
                 % dialogs is small, so we increase it via text formatting.
                 formatSpec = sprintf('\\fontsize{%d}', obj.FontSize);
@@ -105,6 +187,72 @@ classdef MessageDisplay < handle
             else
                 formattedMessage = message;
             end
+        end
+
+        function tf = useModernDialog(obj, functionName)
+            tf = obj.hasDialogFunction(functionName) && obj.hasUiFigureParent();
+        end
+
+        function tf = hasDialogFunction(~, functionName)
+            tf = exist(functionName, 'file') == 2 || exist(functionName, 'builtin') == 5;
+        end
+
+        function tf = hasUiFigureParent(obj)
+            hFigure = obj.getDialogParent();
+            tf = ~isempty(hFigure) && isvalid(hFigure) && ...
+                obj.isUiFigure(hFigure) && strcmp(hFigure.Visible, 'on');
+        end
+
+        function hFigure = getDialogParent(obj)
+            hFigure = [];
+
+            if isempty(obj.App)
+                return
+            elseif isa(obj.App, 'matlab.ui.Figure')
+                hFigure = obj.App;
+            elseif isobject(obj.App) && isprop(obj.App, 'Figure')
+                try
+                    hFigure = obj.App.Figure;
+                catch
+                    hFigure = [];
+                end
+            end
+
+            if isempty(hFigure) || ~isa(hFigure, 'matlab.ui.Figure')
+                hFigure = [];
+            end
+        end
+
+        function tf = isUiFigure(~, hFigure)
+            if verLessThan('matlab', '9.0')
+                tf = false;
+                return
+            end
+
+            try
+                if verLessThan('matlab', '9.5')
+                    tf = ~isempty(matlab.ui.internal.dialog.DialogHelper.getFigureID(hFigure));
+                else
+                    tf = matlab.ui.internal.isUIFigure(hFigure);
+                end
+            catch
+                tf = false;
+            end
+        end
+
+        function icon = getAlertIcon(~, icon, defaultIcon)
+            if strlength(icon) == 0
+                icon = defaultIcon;
+            end
+            icon = char(icon);
+        end
+
+        function cancelOption = getCancelOption(~, alternatives)
+            cancelIdx = find(strcmp(alternatives, "Cancel"), 1, 'first');
+            if isempty(cancelIdx)
+                cancelIdx = numel(alternatives);
+            end
+            cancelOption = char(alternatives(cancelIdx));
         end
     end
 end

--- a/tests/+nansen/+unittest/MessageDisplayTest.m
+++ b/tests/+nansen/+unittest/MessageDisplayTest.m
@@ -1,0 +1,21 @@
+classdef MessageDisplayTest < matlab.unittest.TestCase
+
+    methods (Test, TestTags="Graphical")
+        function testModernProgressDialogForUiFigure(testCase)
+            hFigure = uifigure('Visible', 'on');
+            figureCleanup = onCleanup(@() delete(hFigure));
+
+            messageDisplay = nansen.MessageDisplay(hFigure);
+            hDialog = messageDisplay.wait('Testing progress dialog', ...
+                'Title', 'MessageDisplay Test');
+            dialogCleanup = onCleanup(@() delete(hDialog));
+
+            testCase.verifyClass(hDialog, 'matlab.ui.dialog.ProgressDialog')
+
+            messageDisplay.updateProgress(hDialog, 0.5, 'Halfway');
+            testCase.verifyEqual(hDialog.Value, 0.5, 'AbsTol', eps)
+
+            clear dialogCleanup figureCleanup
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- Add parent-aware modern dialog routing to nansen.MessageDisplay.
- Use uialert, uiconfirm, and uiprogressdlg when the owning NANSEN figure is a visible uifigure.
- Route app progress dialogs through MessageDisplay while keeping legacy dialog fallbacks.
- Add a graphical unit test for the modern uiprogressdlg path.

## Context
MessageDisplay previously always called legacy modal dialog APIs, so NANSEN still opened Java-era dialogs even when running with modern uifigure-backed UI components. This updates the shared message interface so modern app mode uses MATLAB's native uifigure dialog APIs where available.