### PR TITLE
refactor(metatable): refresh metaobject cache in place

### DIFF
--- a/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
+++ b/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
@@ -211,6 +211,76 @@ classdef MetadataEntity < ...
             accessCleanup = onCleanup(@() resetPropertySetAccess(P));
             obj.(variableName) = propertyValue;
         end
+
+        function setTableBackedPropertyValue(obj, propertyName, propertyValue)
+            propertyName = char(propertyName);
+            propertyMeta = obj.findprop(propertyName);
+
+            if isa(propertyMeta, 'meta.DynamicProperty')
+                obj.setDynamicPropertyValue(propertyName, propertyValue)
+            else
+                obj.(propertyName) = propertyValue;
+            end
+        end
+    end
+
+    methods (Access = {?nansen.metadata.MetaTable, ?nansen.metadata.abstract.MetadataEntity})
+        function refreshFromTableRow(obj, tableRow)
+        %refreshFromTableRow Update table-backed properties from one row
+
+            arguments
+                obj (1,1) nansen.metadata.abstract.MetadataEntity
+                tableRow (1,:) table
+            end
+
+            assert(height(tableRow) == 1, ...
+                'NANSEN:MetadataEntity:ExpectedScalarTableRow', ...
+                'Input must be a single table row.')
+
+            rowStruct = table2struct(tableRow);
+            propertyNames = fieldnames(rowStruct);
+
+            for iProperty = 1:numel(propertyNames)
+                obj.refreshProperty(propertyNames{iProperty}, ...
+                    rowStruct.(propertyNames{iProperty}))
+            end
+        end
+
+        function refreshProperty(obj, propertyName, newValue)
+        %refreshProperty Update or create one table-backed property
+
+            arguments
+                obj (1,1) nansen.metadata.abstract.MetadataEntity
+                propertyName (1,1) string
+                newValue
+            end
+
+            propertyNameChar = char(propertyName);
+            if isprop(obj, propertyNameChar)
+                obj.setTableBackedPropertyValue(propertyNameChar, newValue)
+            else
+                obj.createDynamicProperty(propertyName, {newValue})
+            end
+        end
+
+        function removeTableBackedProperty(obj, propertyName)
+        %removeTableBackedProperty Remove a dynamic table-backed property
+
+            arguments
+                obj (1,1) nansen.metadata.abstract.MetadataEntity
+                propertyName (1,1) string
+            end
+
+            propertyNameChar = char(propertyName);
+            if ~isprop(obj, propertyNameChar)
+                return
+            end
+
+            propertyMeta = obj.findprop(propertyNameChar);
+            if isa(propertyMeta, 'meta.DynamicProperty')
+                delete(propertyMeta)
+            end
+        end
     end
 
     methods (Access = private)

--- a/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
+++ b/code/+nansen/+metadata/+abstract/@MetadataEntity/MetadataEntity.m
@@ -224,7 +224,7 @@ classdef MetadataEntity < ...
         end
     end
 
-    methods (Access = {?nansen.metadata.MetaTable, ?nansen.metadata.abstract.MetadataEntity})
+    methods (Access = ?nansen.metadata.MetaTable)
         function refreshFromTableRow(obj, tableRow)
         %refreshFromTableRow Update table-backed properties from one row
 
@@ -338,7 +338,7 @@ classdef MetadataEntity < ...
         end
     end
 
-    methods % Methods for retyping
+    methods % Methods for re-typing
 
         function fromStruct(obj, S)
 

--- a/code/+nansen/+metadata/@MetaTable/MetaTable.m
+++ b/code/+nansen/+metadata/@MetaTable/MetaTable.m
@@ -478,7 +478,7 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
         %   the given rows/column of the entries table and repairs any
         %   cached metaObjects for the edited rows.
         %
-        %   editEntries(..., InvalidateCache=false) skips cache repair.
+        %   editEntries(..., RefreshCache=false) skips cache repair.
         %   Use this only when the edit originates from a live metaObject
         %   (e.g. a property-set sync), where the cached object is already up
         %   to date.
@@ -488,11 +488,11 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
                 rowInd
                 varName
                 newValue
-                options.InvalidateCache (1,1) logical = true
+                options.RefreshCache (1,1) logical = true
             end
 
             obj.assignEntries(rowInd, varName, newValue, ...
-                RefreshCache=options.InvalidateCache)
+                RefreshCache=options.RefreshCache)
             obj.notifyEntryChanged(rowInd, varName)
         end
 
@@ -1490,10 +1490,10 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
             end
 
             % The edit originates from the live metaObject (src), so its
-            % cached entry is already current. Invalidating here would
-            % delete the very object whose property was just set.
+            % cached entry is already current. Refreshing here would only
+            % repeat the property assignment that just happened.
             obj.editEntries(metaTableEntryIdx, propertyName, newValue, ...
-                InvalidateCache=false)
+                RefreshCache=false)
         end
 
         function attachCacheEvictionListener(obj, metaObjects)

--- a/code/+nansen/+metadata/@MetaTable/MetaTable.m
+++ b/code/+nansen/+metadata/@MetaTable/MetaTable.m
@@ -365,11 +365,7 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
                 masterMT.save();
             end
 
-            obj.entries = obj.addTableVariableStatic(obj.entries, variableName, initValue);
-
-            % Cached meta objects mirror the table's column set, so a change
-            % to the columns invalidates them.
-            obj.resetMetaObjectCache()
+            obj.assignTableVariableAdded(variableName, initValue)
         end
 
         function removeTableVariable(obj, variableName)
@@ -379,11 +375,7 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
         %   a table-change event. Callers that maintain views should refresh
         %   them after removing variables.
 
-            obj.entries(:, variableName) = [];
-
-            % Cached meta objects mirror the table's column set, so a change
-            % to the columns invalidates them.
-            obj.resetMetaObjectCache()
+            obj.assignTableVariableRemoved(variableName)
         end
 
         function addTable(obj, T, options)
@@ -483,15 +475,13 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
         %editEntries Edit entries given some parameters.
         %
         %   editEntries(obj, rowInd, varName, newValue) writes newValue into
-        %   the given rows/column of the entries table and invalidates any
-        %   cached metaObjects for the edited rows, so the next
-        %   getMetaObjects call rebuilds them from the updated data.
+        %   the given rows/column of the entries table and repairs any
+        %   cached metaObjects for the edited rows.
         %
-        %   editEntries(..., InvalidateCache=false) skips cache invalidation.
+        %   editEntries(..., InvalidateCache=false) skips cache repair.
         %   Use this only when the edit originates from a live metaObject
         %   (e.g. a property-set sync), where the cached object is already up
-        %   to date and invalidating it would delete the object the caller is
-        %   currently holding.
+        %   to date.
 
             arguments
                 obj
@@ -501,13 +491,8 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
                 options.InvalidateCache (1,1) logical = true
             end
 
-            if options.InvalidateCache
-                editedIds = obj.getObjectId(obj.entries(rowInd, :));
-            end
-            obj.assignEntries(rowInd, varName, newValue)
-            if options.InvalidateCache
-                obj.invalidateMetaObjectCache(editedIds)
-            end
+            obj.assignEntries(rowInd, varName, newValue, ...
+                RefreshCache=options.InvalidateCache)
             obj.notifyEntryChanged(rowInd, varName)
         end
 
@@ -519,15 +504,9 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
                  'The metatable has %d rows, but columnValues has %d elements.'], ...
                 height(obj.entries), numel(columnValues))
 
-            if isa(columnValues, 'cell') % keep for backwards-compatibility
-                % Convert to struct in order to assign values that does not
-                % match type or size of current values
-                tempS = table2struct(obj.entries);
-                [tempS(:).(columnName)] = deal( columnValues{:} );
-                obj.entries = struct2table(tempS, 'AsArray', true);
-            else
-                obj.entries.(columnName) = columnValues;
-            end
+            rowInd = 1:height(obj.entries);
+            obj.assignEntries(rowInd, columnName, columnValues, ...
+                AllowColumnTypeChange=true)
             obj.notifyEntryChanged(':', columnName)
         end
     end
@@ -536,9 +515,7 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
         function editEntriesFromTable(obj, rowInd, varName, newValue)
         %editEntriesFromTable Apply an edit that already originated in a table UI
 
-            editedIds = obj.getObjectId(obj.entries(rowInd, :));
             obj.assignEntries(rowInd, varName, newValue)
-            obj.invalidateMetaObjectCache(editedIds)
         end
     end
 
@@ -590,11 +567,34 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
             obj.notify('TableEntryChanged', evtData)
         end
 
-        function assignEntries(obj, rowInd, varName, newValue)
-        %assignEntries Apply entry values without emitting view-sync events
+        function assignEntries(obj, rowInd, varName, newValue, options)
+        %assignEntries Apply entry values and repair cached metaObjects
+
+            arguments
+                obj (1,1) nansen.metadata.MetaTable
+                rowInd
+                varName
+                newValue
+                options.RefreshCache (1,1) logical = true
+                options.AllowColumnTypeChange (1,1) logical = false
+            end
+
+            rowInd = obj.normalizeRowIndices(rowInd);
+            varName = char(varName);
+
+            if options.RefreshCache
+                editedIds = obj.getObjectId(obj.entries(rowInd, :));
+            end
 
             cleanup = obj.beginEntriesUpdate(); %#ok<NASGU>
-            if isa( obj.entries{rowInd, varName}, 'cell')
+            if options.AllowColumnTypeChange && iscell(newValue)
+                tempS = table2struct(obj.entries);
+                [tempS(rowInd).(varName)] = deal(newValue{:});
+                obj.entries = struct2table(tempS, 'AsArray', true);
+            elseif options.AllowColumnTypeChange ...
+                    && isequal(rowInd, 1:height(obj.entries))
+                obj.entries.(varName) = newValue;
+            elseif isa( obj.entries{rowInd, varName}, 'cell')
                 try
                     obj.entries{rowInd, varName} = newValue;
                 catch % Todo: Better way?
@@ -606,8 +606,190 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
                 obj.entries{rowInd, varName} = newValue;
             end
 
+            if strcmp(varName, obj.SchemaIdName)
+                obj.MetaTableMembers = obj.entries.(obj.SchemaIdName);
+            end
+
             clear cleanup
             obj.onEntriesChanged()
+
+            if options.RefreshCache
+                obj.refreshMetaObjectCacheProperty(editedIds, rowInd, varName)
+            end
+        end
+
+        function assignTableVariableAdded(obj, variableName, initValue)
+        %assignTableVariableAdded Add a column and repair cached metaObjects
+
+            variableName = char(variableName);
+            cleanup = obj.beginEntriesUpdate(); %#ok<NASGU>
+            obj.entries = obj.addTableVariableStatic(obj.entries, variableName, initValue);
+            clear cleanup
+
+            obj.onEntriesChanged()
+            obj.refreshMetaObjectCacheVariableAdded(variableName)
+        end
+
+        function assignTableVariableRemoved(obj, variableName)
+        %assignTableVariableRemoved Remove a column and repair cached metaObjects
+
+            variableName = char(variableName);
+            cleanup = obj.beginEntriesUpdate(); %#ok<NASGU>
+            obj.entries(:, variableName) = [];
+            clear cleanup
+
+            obj.onEntriesChanged()
+            obj.refreshMetaObjectCacheVariableRemoved(variableName)
+        end
+
+        function rowInd = normalizeRowIndices(obj, rowInd)
+        %normalizeRowIndices Resolve row index shorthands to numeric indices
+
+            if isequal(rowInd, ':')
+                rowInd = 1:height(obj.entries);
+            elseif islogical(rowInd)
+                rowInd = find(rowInd);
+            else
+                rowInd = rowInd(:)';
+            end
+        end
+
+        function refreshMetaObjectCacheProperty(obj, objectIds, rowInd, varName)
+        %refreshMetaObjectCacheProperty Refresh one property on cached rows
+
+            objectIds = nansen.metadata.MetaTable.normalizeIdentifier(objectIds);
+            rowInd = obj.normalizeRowIndices(rowInd);
+            varName = char(varName);
+
+            for iObject = 1:numel(objectIds)
+                cacheIdx = obj.findCachedMetaObjectIndex(objectIds{iObject});
+                if isempty(cacheIdx)
+                    continue
+                end
+
+                cachedObject = obj.MetaObjectCache(cacheIdx);
+                if ~obj.isRefreshableMetaObject(cachedObject)
+                    obj.invalidateMetaObjectCache(objectIds(iObject))
+                    continue
+                end
+
+                try
+                    newValue = obj.getTableBackedPropertyValue(rowInd(iObject), varName);
+                    cachedObject.refreshProperty(varName, newValue)
+                catch ME
+                    obj.warnMetaObjectRefreshFailed(objectIds{iObject}, varName, ME)
+                    obj.invalidateMetaObjectCache(objectIds(iObject))
+                end
+            end
+
+            obj.updateMetaObjectCacheMembers();
+        end
+
+        function refreshMetaObjectCacheRows(obj, objectIds, rowInd)
+        %refreshMetaObjectCacheRows Refresh full table rows in cached objects
+
+            objectIds = nansen.metadata.MetaTable.normalizeIdentifier(objectIds);
+            rowInd = obj.normalizeRowIndices(rowInd);
+
+            for iObject = 1:numel(objectIds)
+                cacheIdx = obj.findCachedMetaObjectIndex(objectIds{iObject});
+                if isempty(cacheIdx)
+                    continue
+                end
+
+                cachedObject = obj.MetaObjectCache(cacheIdx);
+                if ~obj.isRefreshableMetaObject(cachedObject)
+                    obj.invalidateMetaObjectCache(objectIds(iObject))
+                    continue
+                end
+
+                try
+                    cachedObject.refreshFromTableRow(obj.entries(rowInd(iObject), :))
+                catch ME
+                    obj.warnMetaObjectRefreshFailed(objectIds{iObject}, "row", ME)
+                    obj.invalidateMetaObjectCache(objectIds(iObject))
+                end
+            end
+
+            obj.updateMetaObjectCacheMembers();
+        end
+
+        function refreshMetaObjectCacheVariableAdded(obj, variableName)
+        %refreshMetaObjectCacheVariableAdded Add/refresh property on cache
+
+            cachedIds = obj.MetaObjectCacheMembers;
+            for iObject = 1:numel(cachedIds)
+                rowInd = obj.getIndexById(cachedIds{iObject});
+                if isempty(rowInd)
+                    continue
+                end
+                obj.refreshMetaObjectCacheProperty(cachedIds(iObject), rowInd, variableName)
+            end
+        end
+
+        function refreshMetaObjectCacheVariableRemoved(obj, variableName)
+        %refreshMetaObjectCacheVariableRemoved Remove property from cache
+
+            cachedIds = obj.MetaObjectCacheMembers;
+            variableName = char(variableName);
+
+            for iObject = 1:numel(cachedIds)
+                cacheIdx = obj.findCachedMetaObjectIndex(cachedIds{iObject});
+                if isempty(cacheIdx)
+                    continue
+                end
+
+                cachedObject = obj.MetaObjectCache(cacheIdx);
+                if ~obj.isRefreshableMetaObject(cachedObject)
+                    obj.invalidateMetaObjectCache(cachedIds(iObject))
+                    continue
+                end
+
+                try
+                    cachedObject.removeTableBackedProperty(variableName)
+                catch ME
+                    obj.warnMetaObjectRefreshFailed(cachedIds{iObject}, variableName, ME)
+                    obj.invalidateMetaObjectCache(cachedIds(iObject))
+                end
+            end
+
+            obj.updateMetaObjectCacheMembers();
+        end
+
+        function cacheIdx = findCachedMetaObjectIndex(obj, objectId)
+        %findCachedMetaObjectIndex Find one cached object by normalized id
+
+            cacheIdx = find(strcmp(obj.MetaObjectCacheMembers, objectId), 1, 'first');
+        end
+
+        function tf = isRefreshableMetaObject(~, metaObject)
+        %isRefreshableMetaObject True for MetadataEntity cache entries
+
+            tf = isa(metaObject, 'nansen.metadata.abstract.MetadataEntity') ...
+                && isvalid(metaObject);
+        end
+
+        function newValue = getTableBackedPropertyValue(obj, rowInd, varName)
+        %getTableBackedPropertyValue Match constructor table-to-property mapping
+
+            rowStruct = table2struct(obj.entries(rowInd, varName));
+            newValue = rowStruct.(varName);
+        end
+
+        function warnMetaObjectRefreshFailed(~, objectId, context, exception)
+        %warnMetaObjectRefreshFailed Warn before falling back to deletion
+
+            if iscell(objectId) && isscalar(objectId)
+                objectId = objectId{1};
+            end
+            objectId = char(string(objectId));
+            context = char(string(context));
+
+            warning('NANSEN:MetaTable:MetaObjectRefreshFailed', ...
+                ['Failed to refresh cached meta object "%s" for "%s". ', ...
+                 'The cached object was deleted and will be rebuilt on ', ...
+                 'the next request. Reason:\n%s'], ...
+                objectId, context, exception.message)
         end
 
         function changeNotifications = getChangedEntryNotifications(~, oldEntries, newEntries, rowIndices)
@@ -644,10 +826,12 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
             [~, targetIdx, sourceIdx] = intersect(obj.MetaTableMembers, sourceMembers);
             updatedEntries = sourceEntries(sourceIdx, :);
             targetEntries = obj.entries(targetIdx, :);
+            updatedEntryIds = {};
 
             cleanup = obj.beginEntriesUpdate(); %#ok<NASGU>
             if ~isequaln(targetEntries, updatedEntries)
                 changedEntryNotifications = obj.getChangedEntryNotifications(targetEntries, updatedEntries, targetIdx);
+                updatedEntryIds = obj.getObjectId(targetEntries);
                 obj.entries(targetIdx, :) = updatedEntries;
                 wasMerged = true;
             end
@@ -666,6 +850,10 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
 
             if wasMerged
                 obj.onEntriesChanged()
+            end
+
+            if ~isempty(updatedEntryIds)
+                obj.refreshMetaObjectCacheRows(updatedEntryIds, targetIdx)
             end
 
             for i = 1:numel(changedEntryNotifications)

--- a/code/+nansen/+metadata/@MetaTable/MetaTable.m
+++ b/code/+nansen/+metadata/@MetaTable/MetaTable.m
@@ -692,6 +692,7 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
             else
                 obj.updateMetaObjectCacheMembers();
             end
+        end
 
         function refreshMetaObjectCacheRows(obj, objectIds, rowInd)
         %refreshMetaObjectCacheRows Refresh full table rows in cached objects

--- a/code/+nansen/+metadata/@MetaTable/MetaTable.m
+++ b/code/+nansen/+metadata/@MetaTable/MetaTable.m
@@ -661,15 +661,20 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
             rowInd = obj.normalizeRowIndices(rowInd);
             varName = char(varName);
 
-            for iObject = 1:numel(objectIds)
-                cacheIdx = obj.findCachedMetaObjectIndex(objectIds{iObject});
-                if isempty(cacheIdx)
-                    continue
-                end
+            if isempty(objectIds) || isempty(obj.MetaObjectCacheMembers)
+                return
+            end
 
-                cachedObject = obj.MetaObjectCache(cacheIdx);
+            [isCached, cacheIdx] = ismember(objectIds, obj.MetaObjectCacheMembers);
+            cachedRows = find(isCached);
+            idsToInvalidate = {};
+
+            for i = 1:numel(cachedRows)
+                iObject = cachedRows(i);
+                cachedObject = obj.MetaObjectCache(cacheIdx(iObject));
+
                 if ~obj.isRefreshableMetaObject(cachedObject)
-                    obj.invalidateMetaObjectCache(objectIds(iObject))
+                    idsToInvalidate(end+1) = objectIds(iObject); %#ok<AGROW>
                     continue
                 end
 
@@ -678,12 +683,15 @@ classdef MetaTable < handle & nansen.metadata.mixin.VersionedFile
                     cachedObject.refreshProperty(varName, newValue)
                 catch ME
                     obj.warnMetaObjectRefreshFailed(objectIds{iObject}, varName, ME)
-                    obj.invalidateMetaObjectCache(objectIds(iObject))
+                    idsToInvalidate(end+1) = objectIds(iObject); %#ok<AGROW>
                 end
             end
 
-            obj.updateMetaObjectCacheMembers();
-        end
+            if ~isempty(idsToInvalidate)
+                obj.invalidateMetaObjectCache(idsToInvalidate)
+            else
+                obj.updateMetaObjectCacheMembers();
+            end
 
         function refreshMetaObjectCacheRows(obj, objectIds, rowInd)
         %refreshMetaObjectCacheRows Refresh full table rows in cached objects

--- a/tests/+nansen/+unittest/+metadata/+helper/RefreshableTestItem.m
+++ b/tests/+nansen/+unittest/+metadata/+helper/RefreshableTestItem.m
@@ -1,0 +1,20 @@
+classdef RefreshableTestItem < nansen.metadata.abstract.MetadataEntity
+    %RefreshableTestItem Minimal MetadataEntity for cache refresh tests.
+
+    properties (Constant, Hidden)
+        ANCESTOR = ''
+        IDNAME = 'itemID'
+    end
+
+    properties (SetObservable)
+        itemID char
+        Value double
+        NonnegativeValue (1,1) double {mustBeNonnegative} = 0
+    end
+
+    methods
+        function obj = RefreshableTestItem(varargin)
+            obj@nansen.metadata.abstract.MetadataEntity(varargin{:})
+        end
+    end
+end

--- a/tests/+nansen/+unittest/+metadata/MetaTableCacheInvalidationTest.m
+++ b/tests/+nansen/+unittest/+metadata/MetaTableCacheInvalidationTest.m
@@ -1,181 +1,231 @@
 classdef MetaTableCacheInvalidationTest < matlab.unittest.TestCase
-    % MetaTableCacheInvalidationTest - Cache invalidation on entry edits
+    %MetaTableCacheInvalidationTest Cache repair for MetaTable metaObjects.
     %
-    %   Regression coverage for issue #101: editEntries must keep the
-    %   metaObject cache consistent with the entries table, while the
-    %   reverse-sync path (a live metaObject updating its own backing row)
-    %   must not delete the object the caller is holding.
-    %
-    %   Regression coverage for issue #104: cached meta objects mirror the
-    %   table's column set (struct objects from the @table2struct fallback),
-    %   so adding or removing a table variable must invalidate the cache.
-    %
-    %   These tests are intentionally self-contained: they build a MetaTable
-    %   backed by a lightweight MetaObjectStub metaObject and do not
-    %   require a configured project.
+    %   These tests cover the cache contract for table-to-object edits:
+    %   MetadataEntity objects refresh in place, unsupported cache entries
+    %   fall back to drop-and-rebuild, and removed rows still delete cached
+    %   handles.
     %
     %   Run tests:
     %       runtests('nansen.unittest.metadata.MetaTableCacheInvalidationTest')
 
     methods (Test)
-        function testEditEntriesInvalidatesMetaObjectCache(testCase)
-            % editEntries must invalidate the cached metaObject so the next
-            % getMetaObjects call reflects the edit.
-            mt = testCase.createObservableItemMetaTable();
-
-            cachedItem = mt.getMetaObjects(1); % Prime the cache
-            testCase.assertClass(cachedItem, ...
-                'nansen.unittest.metadata.helper.MetaObjectStub');
-
-            mt.editEntries(1, 'Value', 9999);
-
-            rebuiltItem = mt.getMetaObjects(1);
-            testCase.verifyEqual(rebuiltItem.Value, 9999, ...
-                'getMetaObjects returned a stale cached object after editEntries');
-
-            % The stale handle should have been invalidated, not silently
-            % kept alive with pre-edit data.
-            testCase.verifyFalse(isvalid(cachedItem));
-        end
-
-        function testEditEntriesWithInvalidateCacheFalseKeepsCache(testCase)
-            % Opting out of invalidation leaves the cached object in place
-            % (used by the reverse-sync path to avoid deleting a live object).
-            mt = testCase.createObservableItemMetaTable();
+        function testEditEntriesRefreshesMetadataEntityInPlace(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
 
             cachedItem = mt.getMetaObjects(1);
-            mt.editEntries(1, 'Value', 9999, 'InvalidateCache', false);
+            mt.editEntries(1, 'Value', 9999);
 
-            testCase.verifyTrue(isvalid(cachedItem), ...
-                'Cached object was deleted despite InvalidateCache=false');
-            sameItem = mt.getMetaObjects(1);
-            testCase.verifyTrue(sameItem == cachedItem, ...
-                'A new object was built despite InvalidateCache=false');
+            refreshedItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(refreshedItem == cachedItem);
+            testCase.verifyTrue(isvalid(cachedItem));
+            testCase.verifyEqual(cachedItem.Value, 9999);
         end
 
-        function testObservablePropertySyncKeepsMetaObjectAlive(testCase)
-            % Editing a live cached metaObject's property syncs into the
-            % entries table without deleting the object the caller holds.
-            mt = testCase.createObservableItemMetaTable();
+        function testReplaceDataColumnRefreshesMetadataEntitiesInPlace(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
 
-            item = mt.getMetaObjects(1);
-            item.Value = 4242;
+            cachedItems = mt.getMetaObjects(1:3);
+            newValues = [101; 102; 103];
+            mt.replaceDataColumn('Value', newValues);
 
-            testCase.verifyTrue(isvalid(item), ...
-                'Live metaObject was deleted by its own property-set sync');
-            testCase.verifyEqual(mt.entries.Value(1), 4242, ...
-                'Property change did not sync back into the entries table');
+            refreshedItems = mt.getMetaObjects(1:3);
+            testCase.verifyTrue(all(refreshedItems == cachedItems));
+            testCase.verifyTrue(all(isvalid(cachedItems)));
+            testCase.verifyEqual([cachedItems.Value]', newValues);
         end
 
-        function testAddTableVariableRebuildsCachedObjects(testCase)
-            % Adding a column must invalidate the cache so the next
-            % getMetaObjects call reflects the new column set (issue #104).
+        function testMergeEntriesRefreshesMetadataEntityInPlace(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            sourceEntries = mt.entries;
+            sourceMembers = mt.members;
+            sourceEntries.Value(1) = 777;
+
+            wasMerged = mt.mergeEntries(sourceEntries, sourceMembers);
+
+            refreshedItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(wasMerged);
+            testCase.verifyTrue(refreshedItem == cachedItem);
+            testCase.verifyTrue(isvalid(cachedItem));
+            testCase.verifyEqual(cachedItem.Value, 777);
+        end
+
+        function testObservablePropertySyncKeepsMetadataEntityAlive(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            cachedItem.Value = 4242;
+
+            testCase.verifyTrue(isvalid(cachedItem));
+            testCase.verifyEqual(mt.entries.Value(1), 4242);
+        end
+
+        function testAddTableVariableAddsDynamicPropertyInPlace(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            testCase.assertFalse(isprop(cachedItem, 'NewVar'));
+
+            mt.addTableVariable('NewVar', 0);
+
+            refreshedItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(refreshedItem == cachedItem);
+            testCase.verifyTrue(isvalid(cachedItem));
+            testCase.verifyTrue(isprop(cachedItem, 'NewVar'));
+            testCase.verifyEqual(cachedItem.NewVar, 0);
+        end
+
+        function testRemoveTableVariableRemovesDynamicPropertyInPlace(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+            mt.addTableVariable('NewVar', 0);
+
+            cachedItem = mt.getMetaObjects(1);
+            testCase.assertTrue(isprop(cachedItem, 'NewVar'));
+
+            mt.removeTableVariable('NewVar');
+
+            refreshedItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(refreshedItem == cachedItem);
+            testCase.verifyTrue(isvalid(cachedItem));
+            testCase.verifyFalse(isprop(cachedItem, 'NewVar'));
+        end
+
+        function testRemoveClassDefinedVariableKeepsClassProperty(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            mt.removeTableVariable('Value');
+
+            refreshedItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(refreshedItem == cachedItem);
+            testCase.verifyTrue(isvalid(cachedItem));
+            testCase.verifyTrue(isprop(cachedItem, 'Value'));
+        end
+
+        function testStructBackedAddTableVariableRebuildsCache(testCase)
             mt = testCase.createStructBackedMetaTable();
 
-            cached = mt.getMetaObjects(1:3); % Prime cache with old column set
+            cached = mt.getMetaObjects(1:3);
             testCase.assertTrue(isstruct(cached));
             testCase.assertFalse(isfield(cached, 'NewVar'));
 
             mt.addTableVariable('NewVar', 0);
 
             rebuilt = mt.getMetaObjects(1:3);
-            testCase.verifyTrue(isfield(rebuilt, 'NewVar'), ...
-                'getMetaObjects served stale cached structs after a column was added');
+            testCase.verifyTrue(isfield(rebuilt, 'NewVar'));
         end
 
-        function testRemoveTableVariableRebuildsCachedObjects(testCase)
-            % Removing a column must invalidate the cache so the next
-            % getMetaObjects call reflects the new column set (issue #104).
+        function testStructBackedRemoveTableVariableRebuildsCache(testCase)
             mt = testCase.createStructBackedMetaTable();
             mt.addTableVariable('NewVar', 0);
 
-            cached = mt.getMetaObjects(1:3); % Prime cache including NewVar
+            cached = mt.getMetaObjects(1:3);
             testCase.assertTrue(isfield(cached, 'NewVar'));
 
             mt.removeTableVariable('NewVar');
 
             rebuilt = mt.getMetaObjects(1:3);
-            testCase.verifyFalse(isfield(rebuilt, 'NewVar'), ...
-                'getMetaObjects served stale cached structs after a column was removed');
+            testCase.verifyFalse(isfield(rebuilt, 'NewVar'));
         end
 
-        function testAddTableVariableAfterPartialCacheDoesNotError(testCase)
-            % Regression for issue #104: when only some rows are cached,
-            % getMetaObjects merges cached structs with freshly built ones.
-            % If a column is added between the two builds, the field sets
-            % must still align (no struct-field mismatch in
-            % utility.insertIntoArray).
+        function testStructBackedPartialCacheAfterAddDoesNotError(testCase)
             mt = testCase.createStructBackedMetaTable();
-            mt.getMetaObjects(1:2); % Cache a subset against the old column set
 
+            mt.getMetaObjects(1:2);
             mt.addTableVariable('NewVar', 0);
 
-            rebuilt = mt.getMetaObjects(1:3); % Previously threw in insertIntoArray
+            rebuilt = mt.getMetaObjects(1:3);
             testCase.verifyEqual(numel(rebuilt), 3);
             testCase.verifyTrue(isfield(rebuilt, 'NewVar'));
         end
 
-        function testDestroyingCachedObjectEvictsItFromCache(testCase)
-            % A cached object carries a cache-eviction listener, so
-            % destroying it removes it from the cache and the next
-            % getMetaObjects rebuilds a valid object rather than returning a
-            % deleted handle.
+        function testNonMetadataEntityHandleFallsBackToDelete(testCase)
             mt = testCase.createObservableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            mt.editEntries(1, 'Value', 9999);
+
+            rebuiltItem = mt.getMetaObjects(1);
+            testCase.verifyFalse(isvalid(cachedItem));
+            testCase.verifyEqual(rebuiltItem.Value, 9999);
+        end
+
+        function testRemoveEntriesDeletesCachedMetadataEntity(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            mt.removeEntries(mt.members{1});
+
+            testCase.verifyFalse(isvalid(cachedItem));
+        end
+
+        function testRefreshFailureWarnsAndDeletesCachedMetadataEntity(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            testCase.verifyWarning( ...
+                @() mt.editEntries(1, 'NonnegativeValue', -1), ...
+                'NANSEN:MetaTable:MetaObjectRefreshFailed');
+
+            testCase.verifyFalse(isvalid(cachedItem));
+        end
+
+        function testDestroyingCachedObjectEvictsItFromCache(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
 
             cachedItem = mt.getMetaObjects(1);
             delete(cachedItem);
 
-            rebuilt = mt.getMetaObjects(1);
-            testCase.verifyTrue(isvalid(rebuilt), ...
-                'Cache returned a stale invalid handle after the cached object was destroyed');
+            rebuiltItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(isvalid(rebuiltItem));
         end
 
         function testDestroyingUncachedObjectDoesNotEvictCachedObject(testCase)
-            % An object fetched with UseCache=false shares its ID with the
-            % cached object for the same row but is not itself cached, so it
-            % carries no cache-eviction listener. Destroying it must not
-            % disturb the live cached object with the same ID.
-            mt = testCase.createObservableItemMetaTable();
+            mt = testCase.createRefreshableItemMetaTable();
 
-            cachedItem = mt.getMetaObjects(1);                    % cached
-            duplicate  = mt.getMetaObjects(1, 'UseCache', false); % same ID, uncached
-            testCase.assertFalse(cachedItem == duplicate, ...
-                'Expected UseCache=false to build a distinct object');
+            cachedItem = mt.getMetaObjects(1);
+            duplicate = mt.getMetaObjects(1, 'UseCache', false);
+            testCase.assertFalse(cachedItem == duplicate);
 
             delete(duplicate);
 
-            rebuilt = mt.getMetaObjects(1);
-            testCase.verifyTrue(rebuilt == cachedItem, ...
-                'Destroying an uncached duplicate evicted the cached object');
+            rebuiltItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(rebuiltItem == cachedItem);
         end
 
         function testRoutineCacheFlowsAreWarningFree(testCase)
-            % The cache-member-missing warning must fire only on a genuine
-            % cache/members desync, never during routine invalidation, reset,
-            % column changes, or direct destruction of a cached object.
-            mt = testCase.createObservableItemMetaTable();
+            mt = testCase.createRefreshableItemMetaTable();
 
-            % editEntries invalidates (deletes) the cached object.
             mt.getMetaObjects(1);
             testCase.verifyWarningFree(@() mt.editEntries(1, 'Value', 111));
 
-            % resetMetaObjectCache deletes every cached object.
             mt.getMetaObjects(1:3);
             testCase.verifyWarningFree(@() mt.resetMetaObjectCache());
 
-            % addTableVariable resets the cache as part of a column change.
             mt.getMetaObjects(1:3);
             testCase.verifyWarningFree(@() mt.addTableVariable('Extra', 0));
 
-            % Directly destroying a cached object evicts it via its listener.
-            item = mt.getMetaObjects(1);
-            testCase.verifyWarningFree(@() delete(item));
+            cachedItem = mt.getMetaObjects(1);
+            testCase.verifyWarningFree(@() delete(cachedItem));
         end
     end
 
     methods (Access = private)
+        function mt = createRefreshableItemMetaTable(~)
+            itemIds = {'item_001'; 'item_002'; 'item_003'};
+            values = [10; 20; 30];
+            nonnegativeValues = [1; 2; 3];
+            entries = table(itemIds, values, nonnegativeValues, ...
+                'VariableNames', {'itemID', 'Value', 'NonnegativeValue'});
+
+            mt = nansen.metadata.MetaTable(entries, ...
+                'MetaTableClass', 'nansen.unittest.metadata.helper.RefreshableTestItem', ...
+                'MetaTableIdVarname', 'itemID');
+        end
+
         function mt = createObservableItemMetaTable(~)
-            % Build a MetaTable backed by MetaObjectStub metaObjects.
             itemIds = {'item_001'; 'item_002'; 'item_003'};
             values = [10; 20; 30];
             entries = table(itemIds, values, ...
@@ -187,9 +237,6 @@ classdef MetaTableCacheInvalidationTest < matlab.unittest.TestCase
         end
 
         function mt = createStructBackedMetaTable(~)
-            % Build a MetaTable with no item class so meta objects are
-            % created via the @table2struct fallback. Each meta object is a
-            % struct whose field set mirrors the current column set.
             itemIds = {'item_001'; 'item_002'; 'item_003'};
             values = [10; 20; 30];
             entries = table(itemIds, values, ...

--- a/tests/+nansen/+unittest/+metadata/MetaTableCacheInvalidationTest.m
+++ b/tests/+nansen/+unittest/+metadata/MetaTableCacheInvalidationTest.m
@@ -22,6 +22,19 @@ classdef MetaTableCacheInvalidationTest < matlab.unittest.TestCase
             testCase.verifyEqual(cachedItem.Value, 9999);
         end
 
+        function testEditEntriesWithRefreshCacheFalseSkipsRefresh(testCase)
+            mt = testCase.createRefreshableItemMetaTable();
+
+            cachedItem = mt.getMetaObjects(1);
+            mt.editEntries(1, 'Value', 9999, RefreshCache=false);
+
+            sameItem = mt.getMetaObjects(1);
+            testCase.verifyTrue(sameItem == cachedItem);
+            testCase.verifyTrue(isvalid(cachedItem));
+            testCase.verifyEqual(cachedItem.Value, 10);
+            testCase.verifyEqual(mt.entries.Value(1), 9999);
+        end
+
         function testReplaceDataColumnRefreshesMetadataEntitiesInPlace(testCase)
             mt = testCase.createRefreshableItemMetaTable();
 
@@ -139,6 +152,19 @@ classdef MetaTableCacheInvalidationTest < matlab.unittest.TestCase
             rebuilt = mt.getMetaObjects(1:3);
             testCase.verifyEqual(numel(rebuilt), 3);
             testCase.verifyTrue(isfield(rebuilt, 'NewVar'));
+        end
+
+        function testStructBackedEditEntriesRebuildsCache(testCase)
+            mt = testCase.createStructBackedMetaTable();
+
+            cached = mt.getMetaObjects(1);
+            testCase.assertTrue(isstruct(cached));
+            testCase.assertEqual(cached.Value, 10);
+
+            mt.editEntries(1, 'Value', 9999);
+
+            rebuilt = mt.getMetaObjects(1);
+            testCase.verifyEqual(rebuilt.Value, 9999);
         end
 
         function testNonMetadataEntityHandleFallsBackToDelete(testCase)


### PR DESCRIPTION
## Summary
- Refresh cached `MetadataEntity` objects in place when metatable entries change.
- Repair cached objects after column add/remove when possible, with drop-and-rebuild fallback for unsupported cache entries.
- Rename the edit skip option to `RefreshCache=false` and cover the skip/fallback paths with regression tests.

## Why
Cached metaObjects could become stale or be deleted while UI/dialog code still held the handle. The cache repair path keeps live `MetadataEntity` handles current and only discards cache entries when they cannot be safely refreshed.